### PR TITLE
DNS Client Implementation and misc. improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,6 @@ Introduction
 
 Pure-Python interface for WIZNET 5k ethernet modules.
 
-NOTE: This library does not currently contain a DNS client. You will need to include a server ip address and destination port in your code.
-
 Dependencies
 =============
 This driver depends on:
@@ -67,24 +65,21 @@ wifitest.adafruit.com.
     from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET
     import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 
-    # Name address for wifitest.adafruit.com
-    SERVER_ADDRESS = (('104.236.193.178'), 80)
-
     cs = digitalio.DigitalInOut(board.D10)
     spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
     # Initialize ethernet interface with DHCP
-    eth = WIZNET(spi_bus, cs)
+    eth = WIZNET5K(spi_bus, cs, debug=True)
 
     print("DHCP Assigned IP: ", eth.pretty_ip(eth.ip_address))
 
     socket.set_interface(eth)
 
-    # Create a new socket
-    sock = socket.socket()
+    host = 'wifitest.adafruit.com'
+    port = 80
 
-    print("Connecting to: ", SERVER_ADDRESS[0])
-    sock.connect(SERVER_ADDRESS)
+    addr_info = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
+    sock = socket.socket(addr_info[0], addr_info[1], addr_info[2])
 
     print("Connected to ", sock.getpeername())
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -47,6 +47,7 @@ from micropython import const
 
 from adafruit_bus_device.spi_device import SPIDevice
 import adafruit_wiznet5k.adafruit_wiznet5k_dhcp as dhcp
+import adafruit_wiznet5k.adafruit_wiznet5k_dns as dns
 
 
 __version__ = "0.0.0-auto.0"
@@ -206,13 +207,27 @@ class WIZNET5K:
             _gw_addr = (_dhcp_client.gateway_ip[0], _dhcp_client.gateway_ip[1],
                         _dhcp_client.gateway_ip[2], _dhcp_client.gateway_ip[3])
 
-            _dns_addr = (_dhcp_client.dns_server_ip[0], _dhcp_client.dns_server_ip[1],
-                         _dhcp_client.dns_server_ip[2], _dhcp_client.dns_server_ip[3])
-            self.ifconfig = ((_ip, _subnet_mask, _gw_addr, _dns_addr))
+            self._dns = (_dhcp_client.dns_server_ip[0], _dhcp_client.dns_server_ip[1],
+                              _dhcp_client.dns_server_ip[2], _dhcp_client.dns_server_ip[3])
+            self.ifconfig = ((_ip, _subnet_mask, _gw_addr, self._dns))
             return 0
-        # Reset SRC_Port
         self._src_port = 0
         return 1
+
+    def get_host_by_name(self, hostname):
+        """Convert a hostname to a packed 4-byte IP Address.
+        Returns a 4 bytearray.
+        """
+        if self._debug:
+            print("* Get host by name")
+        if isinstance(hostname, str):
+            hostname = bytes(hostname, 'utf-8')
+        self._src_port = int(time.monotonic())
+        # Return IP assigned by DHCP
+        _dns_client = dns.DNS(self, self._dns)
+        ret = _dns_client.gethostbyname(hostname)
+        self._src_port = 0
+        return ret
 
     @property
     def max_sockets(self):
@@ -289,10 +304,11 @@ class WIZNET5K:
     def ifconfig(self):
         """Returns the network configuration as a tuple."""
         # set subnet and gateway addresses
+        self._pbuff = bytearray(8)
         for octet in range(0, 4):
             self._pbuff += self.read(REG_SUBR+octet, 0x04)
         for octet in range(0, 4):
-            self._pbuff[3+octet] += self.read(REG_GAR+octet, 0x04)
+            self._pbuff += self.read(REG_GAR+octet, 0x04)
 
         params = (self.ip_address, self._pbuff[0:3], self._pbuff[3:7], self._dns)
         return params
@@ -430,7 +446,6 @@ class WIZNET5K:
         """
         if self._debug:
             print("* socket_available called with protocol", sock_type)
-            print("* #", socket_num)
         assert socket_num <= self.max_sockets, "Provided socket exceeds max_sockets."
 
         if sock_type == 0x02:
@@ -490,6 +505,7 @@ class WIZNET5K:
             self._read_sncr(socket_num)
             # wait for tcp connection establishment
             while self.socket_status(socket_num)[0] != SNSR_SOCK_ESTABLISHED:
+                print(self.socket_status(socket_num)[0])
                 if self.socket_status(socket_num)[0] == SNSR_SOCK_CLOSED:
                     raise RuntimeError('Failed to establish connection.')
                 time.sleep(1)
@@ -556,15 +572,18 @@ class WIZNET5K:
         return 1
 
     def socket_close(self, socket_num):
-        """Closes a socket.
-
-        """
-        assert self.link_status, "Ethernet cable disconnected!"
+        """Closes a socket."""
         if self._debug:
             print("*** Closing socket #%d" % socket_num)
         self._write_sncr(socket_num, CMD_SOCK_CLOSE)
         self._read_sncr(socket_num)
-        self._write_snir(socket_num, 0xFF)
+
+    def socket_disconnect(self, socket_num):
+        """Disconnect a TCP connection."""
+        if self._debug:
+            print("*** Disconnecting socket #%d" % socket_num)
+        self._write_sncr(socket_num, CMD_SOCK_DISCON)
+        self._read_sncr(socket_num)
 
     def socket_read(self, socket_num, length):
         """Reads data from a socket into a buffer.
@@ -673,7 +692,7 @@ class WIZNET5K:
         # check data was  transferred correctly
         while(self._read_socket(socket_num, REG_SNIR)[0] & SNIR_SEND_OK) != SNIR_SEND_OK:
             if self.socket_status(socket_num) == SNSR_SOCK_CLOSED:
-                self.socket_close(socket_num)
+                #self.socket_close(socket_num)
                 return 0
             time.sleep(0.01)
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -208,7 +208,7 @@ class WIZNET5K:
                         _dhcp_client.gateway_ip[2], _dhcp_client.gateway_ip[3])
 
             self._dns = (_dhcp_client.dns_server_ip[0], _dhcp_client.dns_server_ip[1],
-                              _dhcp_client.dns_server_ip[2], _dhcp_client.dns_server_ip[3])
+                         _dhcp_client.dns_server_ip[2], _dhcp_client.dns_server_ip[3])
             self.ifconfig = ((_ip, _subnet_mask, _gw_addr, self._dns))
             return 0
         self._src_port = 0

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -505,7 +505,6 @@ class WIZNET5K:
             self._read_sncr(socket_num)
             # wait for tcp connection establishment
             while self.socket_status(socket_num)[0] != SNSR_SOCK_ESTABLISHED:
-                print(self.socket_status(socket_num)[0])
                 if self.socket_status(socket_num)[0] == SNSR_SOCK_CLOSED:
                     raise RuntimeError('Failed to establish connection.')
                 time.sleep(1)

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -72,7 +72,7 @@ MAX_DHCP_OPT = const(0x10)
 DHCP_SERVER_PORT   = const(67)
 # DHCP Lease Time, in seconds
 DEFAULT_LEASE_TIME = const(900)
-BROADCAST_SERVER_ADDR = 255, 255, 255, 255
+BROADCAST_SERVER_ADDR = (('255.255.255.255'))
 
 # pylint: enable=bad-whitespace
 _BUFF = bytearray(317)
@@ -120,7 +120,7 @@ class DHCP:
     def send_dhcp_message(self, state, time_elapsed):
         """Assemble and send a DHCP message packet to a socket.
         :param int state: DHCP Message state.
-        :param float time_elapsed: Number of seconds elapsed since client attempted to renew lease.
+        :param float time_elapsed: Number of seconds elapsed since client attempted to acquire/renew a lease.
 
         """
         # OP
@@ -264,8 +264,10 @@ class DHCP:
         self._t2 = int.from_bytes(_BUFF[263:267], 'l')
         # Subnet Mask
         self.subnet_mask = _BUFF[269:273]
+        print(_BUFF)
+        #time.sleep(100)
         # DNS Server
-        self.dns_server_ip = _BUFF[285:289]
+        self.dns_server_ip = _BUFF[281:285]
 
         return msg_type, xid
 
@@ -322,4 +324,6 @@ class DHCP:
 
         self._transaction_id += 1
         self._last_check_lease_ms = time.monotonic()
+        # close the socket, we're done with it
+        self._sock.close()
         return result

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -120,8 +120,7 @@ class DHCP:
     def send_dhcp_message(self, state, time_elapsed):
         """Assemble and send a DHCP message packet to a socket.
         :param int state: DHCP Message state.
-        :param float time_elapsed: Number of seconds elapsed since
-                                   client attempted to acquire/renew a lease.
+        :param float time_elapsed: Number of seconds elapsed since renewal.
 
         """
         # OP

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -120,7 +120,8 @@ class DHCP:
     def send_dhcp_message(self, state, time_elapsed):
         """Assemble and send a DHCP message packet to a socket.
         :param int state: DHCP Message state.
-        :param float time_elapsed: Number of seconds elapsed since client attempted to acquire/renew a lease.
+        :param float time_elapsed: Number of seconds elapsed since
+                                   client attempted to acquire/renew a lease.
 
         """
         # OP

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -265,8 +265,6 @@ class DHCP:
         self._t2 = int.from_bytes(_BUFF[263:267], 'l')
         # Subnet Mask
         self.subnet_mask = _BUFF[269:273]
-        print(_BUFF)
-        #time.sleep(100)
         # DNS Server
         self.dns_server_ip = _BUFF[281:285]
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -72,7 +72,7 @@ MAX_DHCP_OPT = const(0x10)
 DHCP_SERVER_PORT   = const(67)
 # DHCP Lease Time, in seconds
 DEFAULT_LEASE_TIME = const(900)
-BROADCAST_SERVER_ADDR = (('255.255.255.255'))
+BROADCAST_SERVER_ADDR = '255.255.255.255'
 
 # pylint: enable=bad-whitespace
 _BUFF = bytearray(317)
@@ -283,7 +283,7 @@ class DHCP:
         while self._dhcp_state != STATE_DHCP_LEASED:
             if self._dhcp_state == STATE_DHCP_START:
                 self._transaction_id += 1
-                self._sock.connect((BROADCAST_SERVER_ADDR, DHCP_SERVER_PORT))
+                self._sock.connect(((BROADCAST_SERVER_ADDR), DHCP_SERVER_PORT))
                 self.send_dhcp_message(STATE_DHCP_DISCOVER,
                                        ((time.monotonic() - start_time) / 1000))
                 self._dhcp_state = STATE_DHCP_DISCOVER

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -36,6 +36,8 @@ from micropython import const
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 from adafruit_wiznet5k.adafruit_wiznet5k_socket import htons
 
+# pylint: disable=bad-whitespace
+
 QUERY_FLAG             = const(0x00)
 OPCODE_STANDARD_QUERY  = const(0x00)
 RECURSION_DESIRED_FLAG = 1<<8
@@ -51,7 +53,8 @@ INVALID_SERVER   = const(-2)
 TRUNCATED        = const(-3)
 INVALID_RESPONSE = const(-4)
 
-DNS_PORT = const(0x35) # port used for DNS request
+DNS_PORT         = const(0x35) # port used for DNS request
+# pylint: enable=bad-whitespace
 
 class DNS:
     """W5K DNS implementation.
@@ -91,8 +94,8 @@ class DNS:
         addr = -1
         while (retries < 3) and (addr == -1):
             addr = self._parse_dns_response()
-            retries+=1
-        
+            retries += 1
+
         self._sock.close()
         return addr
 
@@ -116,7 +119,6 @@ class DNS:
         # Validate request identifier
         if not hex(int.from_bytes(self._pkt_buf[0:2], 'l')) == hex(self._request_id):
             return -1
-
         # Validate flags
         if not int.from_bytes(self._pkt_buf[2:4], 'l') == 0x8180:
             return -1
@@ -136,11 +138,8 @@ class DNS:
                     return -1
                 # return the address
                 return self._pkt_buf[51:55]
-            else:
-                # not the correct answer type or class
-                an_count+=1
-
-        return -1
+            # not the correct answer type or class
+            an_count += 1
 
     def _build_dns_header(self):
         """Builds DNS header."""
@@ -186,5 +185,3 @@ class DNS:
         # Class IN
         self._pkt_buf.append(htons(CLASS_IN) & 0xFF)
         self._pkt_buf.append(htons(CLASS_IN) >> 8)
-
-

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -117,7 +117,7 @@ class DNS:
         self._pkt_buf = self._sock.recv(packet_sz)[0]
 
         # Validate request identifier
-        if not hex(int.from_bytes(self._pkt_buf[0:2], 'l')) == hex(self._request_id):
+        if not int.from_bytes(self._pkt_buf[0:2], 'l') == self._request_id:
             return -1
         # Validate flags
         if not int.from_bytes(self._pkt_buf[2:4], 'l') == 0x8180:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -1,0 +1,190 @@
+# The MIT License (MIT)
+#
+# (c) Copyright 2009-2010 MCQN Ltd
+# Modified by Brent Rubell for Adafruit Industries, 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_wiznet5k_dns`
+================================================================================
+
+Pure-Python implementation of the Arduino DNS client for WIZnet 5k-based
+ethernet modules.
+
+* Author(s): MCQN Ltd, Brent Rubell
+
+"""
+import time
+from random import getrandbits
+from micropython import const
+import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
+from adafruit_wiznet5k.adafruit_wiznet5k_socket import htons
+
+QUERY_FLAG             = const(0x00)
+OPCODE_STANDARD_QUERY  = const(0x00)
+RECURSION_DESIRED_FLAG = 1<<8
+
+TYPE_A   = const(0x0001)
+CLASS_IN = const(0x0001)
+DATA_LEN = const(0x0004)
+
+# Return codes for gethostbyname
+SUCCESS          = const(1)
+TIMED_OUT        = const(-1)
+INVALID_SERVER   = const(-2)
+TRUNCATED        = const(-3)
+INVALID_RESPONSE = const(-4)
+
+DNS_PORT = const(0x35) # port used for DNS request
+
+class DNS:
+    """W5K DNS implementation.
+
+    :param iface: Network interface
+    """
+    def __init__(self, iface, dns_address):
+        self._iface = iface
+        socket.set_interface(iface)
+        self._sock = socket.socket(type=socket.SOCK_DGRAM)
+        self._sock.settimeout(1)
+
+        self._dns_server = dns_address
+        self._host = 0
+        self._request_id = 0 # request identifier
+        self._pkt_buf = bytearray()
+
+    def gethostbyname(self, hostname):
+        """Translate a host name to IPv4 address format.
+        :param str hostname: Desired host name to connect to.
+
+        Returns the IPv4 address as a bytearray if successful, -1 otherwise.
+        """
+        if self._dns_server is None:
+            return INVALID_SERVER
+        self._host = hostname
+        # build DNS request packet
+        self._build_dns_header()
+        self._build_dns_question()
+
+        # Send DNS request packet
+        self._sock.connect((self._dns_server, DNS_PORT))
+        self._sock.send(self._pkt_buf)
+
+        # wait and retry 3 times for a response
+        retries = 0
+        addr = -1
+        while (retries < 3) and (addr == -1):
+            addr = self._parse_dns_response()
+            retries+=1
+        
+        self._sock.close()
+        return addr
+
+    def _parse_dns_response(self):
+        """Receives and parses DNS query response.
+        Returns desired hostname address if obtained, -1 otherwise.
+
+        """
+        # wait for a response
+        start_time = time.monotonic()
+        packet_sz = self._sock.available()
+        while packet_sz <= 0:
+            packet_sz = self._sock.available()
+            if (time.monotonic() - start_time) > 1.0:
+                # timed out!
+                return -1
+            time.sleep(0.05)
+        # store packet in buffer
+        self._pkt_buf = self._sock.recv(packet_sz)[0]
+
+        # Validate request identifier
+        if not hex(int.from_bytes(self._pkt_buf[0:2], 'l')) == hex(self._request_id):
+            return -1
+
+        # Validate flags
+        if not int.from_bytes(self._pkt_buf[2:4], 'l') == 0x8180:
+            return -1
+        # Validate Answer RRs (>=1)
+        an_count = int.from_bytes(self._pkt_buf[6:8], 'l')
+        if not an_count >= 1:
+            return -1
+
+        # iterate over ANCOUNT since answer may not be type A
+        while an_count > 0:
+            ans_type = int.from_bytes(self._pkt_buf[41:43], 'l')
+            ans_class = int.from_bytes(self._pkt_buf[43:45], 'l')
+            ans_len = int.from_bytes(self._pkt_buf[49:51], 'l')
+            if  ans_type == TYPE_A and ans_class == CLASS_IN:
+                if ans_len != 4:
+                    # invalid size ret.'d
+                    return -1
+                # return the address
+                return self._pkt_buf[51:55]
+            else:
+                # not the correct answer type or class
+                an_count+=1
+
+        return -1
+
+    def _build_dns_header(self):
+        """Builds DNS header."""
+        # generate a random, 16-bit, request identifier
+        self._request_id = getrandbits(16)
+
+        # ID, 16-bit identifier
+        self._pkt_buf.append(self._request_id >> 8)
+        self._pkt_buf.append(self._request_id & 0xFF)
+
+        # Flags (0x0100)
+        self._pkt_buf.append(0x01)
+        self._pkt_buf.append(0x00)
+
+        # QDCOUNT
+        self._pkt_buf.append(0x00)
+        self._pkt_buf.append(0x01)
+        # ANCOUNT
+        self._pkt_buf.append(0x00)
+        self._pkt_buf.append(0x00)
+        # NSCOUNT
+        self._pkt_buf.append(0x00)
+        self._pkt_buf.append(0x00)
+        #ARCOUNT
+        self._pkt_buf.append(0x00)
+        self._pkt_buf.append(0x00)
+
+    def _build_dns_question(self):
+        """Build DNS question"""
+        host = self._host.decode('utf-8')
+        host = host.split(".")
+        # write out each section of host
+        for i, _ in enumerate(host):
+            # append the sz of the section
+            self._pkt_buf.append(len(host[i]))
+            # append the section data
+            self._pkt_buf += host[i]
+        # end of the name
+        self._pkt_buf.append(0x00)
+        # Type A record
+        self._pkt_buf.append(htons(TYPE_A) & 0xFF)
+        self._pkt_buf.append(htons(TYPE_A) >> 8)
+        # Class IN
+        self._pkt_buf.append(htons(CLASS_IN) & 0xFF)
+        self._pkt_buf.append(htons(CLASS_IN) >> 8)
+
+

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -60,6 +60,7 @@ NO_SOCKET_AVAIL = const(255)
 # keep track of sockets we allocate
 SOCKETS = []
 
+#pylint: disable=too-many-arguments, unused-argument
 def getaddrinfo(host, port, family=0, socktype=0, proto=0, flags=0):
     """Translate the host/port argument into a sequence of 5-tuples that
     contain all the necessary arguments for creating a socket connected to that service.
@@ -74,9 +75,9 @@ def gethostbyname(hostname):
     is returned as a string.
     :param str hostname: Desired hostname.
     """
-    ip = _the_interface.get_host_by_name(hostname)
-    ip = "{}.{}.{}.{}".format(ip[0], ip[1], ip[2], ip[3])
-    return ip
+    addr = _the_interface.get_host_by_name(hostname)
+    addr = "{}.{}.{}.{}".format(addr[0], addr[1], addr[2], addr[3])
+    return addr
 
 #pylint: disable=invalid-name
 class socket:
@@ -86,12 +87,12 @@ class socket:
     :param int type: Socket type.
 
     """
-    # pylint: disable=redefined-builtin
+    # pylint: disable=redefined-builtin,unused-argument
     def __init__(self, family=AF_INET, type=SOCK_STREAM, proto=0, fileno=None, socknum=None):
         if family != AF_INET:
             raise RuntimeError("Only AF_INET family supported by W5K modules.")
         self._sock_type = type
-        self._buffer = b''
+        self._buffer = b""
         self._timeout = 0
 
         self._socknum = _the_interface.get_socket(SOCKETS)
@@ -129,10 +130,10 @@ class socket:
         :param str ip_string: IP Address, as a dotted-quad string.
 
         """
-        self._bufffer = b""
-        self._bufffer = [int(item) for item in ip_string.split('.')]
-        self._bufffer = bytearray(self._bufffer)
-        return self._bufffer
+        self._buffer = b''
+        self._buffer = [int(item) for item in ip_string.split('.')]
+        self._buffer = bytearray(self._buffer)
+        return self._buffer
 
     def connect(self, address, conntype=None):
         """Connect to a remote socket at address. (The format of address depends

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -145,7 +145,6 @@ class socket:
 
         if hasattr(host, 'split'):
             host = tuple(map(int, host.split('.')))
-        print(self._sock_type)
         if not _the_interface.socket_connect(self.socknum, host, port, conn_mode=self._sock_type):
             raise RuntimeError("Failed to connect to host", host)
         self._buffer = b''
@@ -156,7 +155,6 @@ class socket:
         :param bytearray data: Desired data to send to the socket.
 
         """
-        print(self.socknum, data)
         _the_interface.socket_write(self.socknum, data)
         gc.collect()
 

--- a/examples/wiznet5k_simpletest.py
+++ b/examples/wiznet5k_simpletest.py
@@ -6,24 +6,21 @@ import digitalio
 from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 
-# Name address for wifitest.adafruit.com
-SERVER_ADDRESS = (('104.236.193.178'), 80)
-
 cs = digitalio.DigitalInOut(board.D10)
 spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # Initialize ethernet interface with DHCP
-eth = WIZNET5K(spi_bus, cs)
+eth = WIZNET5K(spi_bus, cs, debug=True)
 
 print("DHCP Assigned IP: ", eth.pretty_ip(eth.ip_address))
 
 socket.set_interface(eth)
 
-# Create a new socket
-sock = socket.socket()
+host = 'wifitest.adafruit.com'
+port = 80
 
-print("Connecting to: ", SERVER_ADDRESS[0])
-sock.connect(SERVER_ADDRESS)
+addr_info = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
+sock = socket.socket(addr_info[0], addr_info[1], addr_info[2])
 
 print("Connected to ", sock.getpeername())
 

--- a/examples/wiznet5k_simpletest.py
+++ b/examples/wiznet5k_simpletest.py
@@ -10,7 +10,7 @@ cs = digitalio.DigitalInOut(board.D10)
 spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # Initialize ethernet interface with DHCP
-eth = WIZNET5K(spi_bus, cs, debug=True)
+eth = WIZNET5K(spi_bus, cs)
 
 print("DHCP Assigned IP: ", eth.pretty_ip(eth.ip_address))
 
@@ -21,6 +21,8 @@ port = 80
 
 addr_info = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
 sock = socket.socket(addr_info[0], addr_info[1], addr_info[2])
+
+sock.connect(addr_info[4])
 
 print("Connected to ", sock.getpeername())
 


### PR DESCRIPTION
- Added `adafruit_wiznet5k_dns.py`, a dns client implementation
- updated example for dns client
- updated `README.rst` to reflect library status, after this pr
- added `gethostbyname`, `getaddrinfo` methods to socket, to mock cpython socket-type object
- close allocated udp socket after completed dhcp or dns, freeing it up for re-allocation
- added `socket_disconnect` method to wiznet5k to gracefully disconnect TCP sockets, linked in `adafruit_wiznet5k_socket`

**NOTE:** this pull request is **not** compatible with Adafruit_CircuitPython_Requests, a future pull request will add compatibility for this library.

Tested on `Adafruit CircuitPython 5.0.0-beta.5 on 2020-02-05; Adafruit Feather M4 Express with samd51j19`
```
DHCP Assigned IP:  192.[snip]
Connected to  104.236.193.178
bytearray(b'HTTP/1.1 200 OK\r\nServer: nginx/1.10.3 (Ubuntu)\r\nDate: Fri, 28 Feb 2020 23:05:50 GMT\r\nContent-Type: text/html\r\nContent-Length: 70\r\nLast-Modified: Thu, 16 May 2019 18:21:16 GMT\r\nConnection: close\r\nETag: "5cddaa1c-46"\r\nAccept-Ranges: bytes\r\n\r\nThis is a test of Adafruit WiFi!\nIf you can read this, its working :)\n')
Received: 310 bytes
Rate = 0.00067 kbytes/second
```