### PR TITLE
Fix TypeError on recv

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -97,7 +97,7 @@ class socket:
 
         self._socknum = _the_interface.get_socket(SOCKETS)
         SOCKETS.append(self._socknum)
-        self.settimeout(1)
+        self.settimeout(self._timeout)
 
     @property
     def socknum(self):
@@ -144,6 +144,7 @@ class socket:
         assert conntype != 0x03, "Error: SSL/TLS is not currently supported by CircuitPython."
         host, port = address
 
+        print(address)
         if hasattr(host, 'split'):
             host = tuple(map(int, host.split('.')))
         if not _the_interface.socket_connect(self.socknum, host, port, conn_mode=self._sock_type):
@@ -164,7 +165,7 @@ class socket:
         """Reads some bytes from the connected remote address.
         :param int bufsize: Maximum number of bytes to receive.
         """
-        # print("Socket read", bufsize)
+        print("Socket read", bufsize)
         if bufsize == 0:
             # read everything on the socket
             while True:
@@ -186,24 +187,31 @@ class socket:
             return ret
         stamp = time.monotonic()
 
+
         to_read = bufsize - len(self._buffer)
         received = []
         while to_read > 0:
+            print("Bytes to read:", to_read)
             if self._sock_type == SOCK_STREAM:
                 avail = self.available()
             elif self._sock_type == SOCK_DGRAM:
                 avail = _the_interface.udp_remaining()
+            #print('Bytes Avail: ', avail)
             if avail:
                 stamp = time.monotonic()
                 if self._sock_type == SOCK_STREAM:
+                    print("to_read: {}\navail:{}\n".format(to_read, avail))
                     recv = _the_interface.socket_read(self.socknum, min(to_read, avail))[1]
                 elif self._sock_type == SOCK_DGRAM:
                     recv = _the_interface.read_udp(self.socknum, min(to_read, avail))[1]
+                print('RCV: ', recv)
+                recv = bytes(recv)
                 received.append(recv)
                 to_read -= len(recv)
                 gc.collect()
             if self._timeout > 0 and time.monotonic() - stamp > self._timeout:
                 break
+        print("{}, \nType:{}".format(received, type(received)))
         self._buffer += b''.join(received)
 
         ret = None

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -144,7 +144,6 @@ class socket:
         assert conntype != 0x03, "Error: SSL/TLS is not currently supported by CircuitPython."
         host, port = address
 
-        print(address)
         if hasattr(host, 'split'):
             host = tuple(map(int, host.split('.')))
         if not _the_interface.socket_connect(self.socknum, host, port, conn_mode=self._sock_type):
@@ -165,7 +164,7 @@ class socket:
         """Reads some bytes from the connected remote address.
         :param int bufsize: Maximum number of bytes to receive.
         """
-        print("Socket read", bufsize)
+        # print("Socket read", bufsize)
         if bufsize == 0:
             # read everything on the socket
             while True:
@@ -191,27 +190,23 @@ class socket:
         to_read = bufsize - len(self._buffer)
         received = []
         while to_read > 0:
-            print("Bytes to read:", to_read)
+            # print("Bytes to read:", to_read)
             if self._sock_type == SOCK_STREAM:
                 avail = self.available()
             elif self._sock_type == SOCK_DGRAM:
                 avail = _the_interface.udp_remaining()
-            #print('Bytes Avail: ', avail)
             if avail:
                 stamp = time.monotonic()
                 if self._sock_type == SOCK_STREAM:
-                    print("to_read: {}\navail:{}\n".format(to_read, avail))
                     recv = _the_interface.socket_read(self.socknum, min(to_read, avail))[1]
                 elif self._sock_type == SOCK_DGRAM:
                     recv = _the_interface.read_udp(self.socknum, min(to_read, avail))[1]
-                print('RCV: ', recv)
                 recv = bytes(recv)
                 received.append(recv)
                 to_read -= len(recv)
                 gc.collect()
             if self._timeout > 0 and time.monotonic() - stamp > self._timeout:
                 break
-        print("{}, \nType:{}".format(received, type(received)))
         self._buffer += b''.join(received)
 
         ret = None


### PR DESCRIPTION
* Fixes TypeError message thrown by `recv()` reading a specific amount of bytes, useful for applications which require socket to receive a specific amount of bytes (protocol implementations, like MQTT):

from (typeerror):
```
Traceback (most recent call last):
  File "code.py", line 74, in <module>
  File "/lib/adafruit_minimqtt.py", line 304, in connect
  File "/lib/adafruit_minimqtt.py", line 621, in _wait_for_msg
  File "/lib/adafruit_wiznet5k/adafruit_wiznet5k_socket.py", line 210, in recv
TypeError: join expects a list of str/bytes objects consistent with self object
```
to:
```
Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
Connecting to Adafruit IO...
Connected to Adafruit IO! Listening for topic changes on brubell/feeds/onoff
Sending photocell value: 0...
```
* Sets socket `timeout` to a default `timeout`

