### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -53,7 +53,6 @@ import adafruit_wiznet5k.adafruit_wiznet5k_dns as dns
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k.git"
 
-# pylint: disable=bad-whitespace
 
 # Wiznet5k Registers
 REG_MR = const(0x0000)  # Mode
@@ -124,7 +123,6 @@ SNMR_IPRAW = const(0x03)
 SNMR_MACRAW = const(0x04)
 SNMR_PPPOE = const(0x05)
 
-# pylint: enable=bad-whitespace
 MAX_PACKET = const(4000)
 LOCAL_PORT = const(0x400)
 # Default hardware MAC address

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -36,7 +36,6 @@ from micropython import const
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 from adafruit_wiznet5k.adafruit_wiznet5k_socket import htonl, htons
 
-# pylint: disable=bad-whitespace
 
 # DHCP State Machine
 STATE_DHCP_START = const(0x00)
@@ -87,7 +86,6 @@ LEASE_TIME = 51
 OPT_END = 255
 
 
-# pylint: enable=bad-whitespace
 _BUFF = bytearray(317)
 
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -36,7 +36,6 @@ from micropython import const
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 from adafruit_wiznet5k.adafruit_wiznet5k_socket import htons
 
-# pylint: disable=bad-whitespace
 
 QUERY_FLAG = const(0x00)
 OPCODE_STANDARD_QUERY = const(0x00)
@@ -54,7 +53,6 @@ TRUNCATED = const(-3)
 INVALID_RESPONSE = const(-4)
 
 DNS_PORT = const(0x35)  # port used for DNS request
-# pylint: enable=bad-whitespace
 
 
 class DNS:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -58,13 +58,11 @@ def htons(x):
     return (((x) << 8) & 0xFF00) | (((x) >> 8) & 0xFF)
 
 
-# pylint: disable=bad-whitespace
 SOCK_STREAM = const(0x21)  # TCP
 TCP_MODE = 80
 SOCK_DGRAM = const(0x02)  # UDP
 AF_INET = const(3)
 NO_SOCKET_AVAIL = const(255)
-# pylint: enable=bad-whitespace
 
 # keep track of sockets we allocate
 SOCKETS = []

--- a/examples/wiznet5k_aio_post.py
+++ b/examples/wiznet5k_aio_post.py
@@ -2,9 +2,9 @@ import time
 import board
 import busio
 from digitalio import DigitalInOut
+import adafruit_requests as requests
 from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
-import adafruit_requests as requests
 
 # Get Adafruit.io details from a secrets.py file
 try:

--- a/examples/wiznet5k_cheerlights.py
+++ b/examples/wiznet5k_cheerlights.py
@@ -51,7 +51,7 @@ while True:
             raise AssertionError(
                 "Failed to resolve hostname, \
                                   please check your router's DNS configuration."
-            )
+            ) from error
         continue
     if not value:
         continue

--- a/examples/wiznet5k_cheerlights.py
+++ b/examples/wiznet5k_cheerlights.py
@@ -3,12 +3,12 @@ import board
 import busio
 from digitalio import DigitalInOut
 
-from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
-import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 import adafruit_requests as requests
 
 import neopixel
 import adafruit_fancyled.adafruit_fancyled as fancy
+from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
+import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 
 cs = DigitalInOut(board.D10)
 spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.