### PR TITLE
Accept Authoritative DNS Responses

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -140,7 +140,7 @@ class DNS:
             return -1
         # Validate flags
         flags = int.from_bytes(self._pkt_buf[2:4], "l")
-        if not (flags == 0x8180 or flags == 0x8580):
+        if not flags in (0x8180, 0x8580):
             if self._debug:
                 print("* DNS ERROR: Invalid flags, ", flags)
             return -1

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -140,7 +140,7 @@ class DNS:
             return -1
         # Validate flags
         flags = int.from_bytes(self._pkt_buf[2:4], "l")
-        if not flags == 0x8180:
+        if not (flags == 0x8180 or flags == 0x8580):
             if self._debug:
                 print("* DNS ERROR: Invalid flags, ", flags)
             return -1


### PR DESCRIPTION
By adding 0x8580 as an allowed response flag, responses with the 'authoritative' bit set to 1 will now be treated as a valid response

This works a temporary fix to #25 but to be correct, the flags probably need to be parsed individually.