### PR TITLE
Accept method

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -612,7 +612,9 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
         next_socknum = self.get_socket()
         if self._debug:
             print(
-                f"* Dest is ({dest_ip}, {dest_port}), Next listen socknum is #{next_socknum}"
+                "* Dest is ({}, {}), Next listen socknum is #{}".format(
+                    dest_ip, dest_port, next_socknum
+                )
             )
         return next_socknum, (dest_ip, dest_port)
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -30,6 +30,7 @@ Implementation Notes
 from random import randint
 import time
 from micropython import const
+
 from adafruit_bus_device.spi_device import SPIDevice
 import adafruit_wiznet5k.adafruit_wiznet5k_dhcp as dhcp
 import adafruit_wiznet5k.adafruit_wiznet5k_dns as dns

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -118,6 +118,10 @@ class socket:
             if time.monotonic() - stamp > 1000:
                 raise RuntimeError("Failed to disconnect socket")
         self.close()
+        stamp = time.monotonic()
+        while self.status != adafruit_wiznet5k.SNSR_SOCK_CLOSED:
+            if time.monotonic() - stamp > 1000:
+                raise RuntimeError("Failed to close socket")
 
     @property
     def socknum(self):

--- a/examples/wiznet5k_simpleserver.py
+++ b/examples/wiznet5k_simpleserver.py
@@ -24,7 +24,7 @@ eth = WIZNET5K(spi_bus, cs, is_dhcp=False)
 socket.set_interface(eth)
 server = socket.socket()  # Allocate socket for the server
 server_ip = "192.168.10.1"  # IP address of server
-server_port = 50007  # Port to listen on 
+server_port = 50007  # Port to listen on
 server.bind((server_ip, server_port))  # Bind to IP and Port
 server.listen()  # Begin listening for incoming clients
 

--- a/examples/wiznet5k_simpleserver.py
+++ b/examples/wiznet5k_simpleserver.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 Adam Cummick
+#
+# SPDX-License-Identifier: MIT
+
+import board
+import busio
+import digitalio
+from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
+import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
+
+print("Wiznet5k SimpleServer Test")
+
+# For Adafruit Ethernet FeatherWing
+cs = digitalio.DigitalInOut(board.D10)
+# For Particle Ethernet FeatherWing
+# cs = digitalio.DigitalInOut(board.D5)
+spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+
+# Initialize ethernet interface
+eth = WIZNET5K(spi_bus, cs, is_dhcp=False)
+
+# Initialize a socket for our server
+socket.set_interface(eth)
+server = socket.socket()  # Allocate socket for the server
+server_ip = "192.168.10.1"  # IP address of server
+server_port = 50007  # Port to listen on 
+server.bind((server_ip, server_port))  # Bind to IP and Port
+server.listen()  # Begin listening for incoming clients
+
+while True:
+    conn, addr = server.accept()  # Wait for a connection from a client.
+    with conn:
+        data = conn.recv()
+        print(data)
+        conn.send(data)  # Echo message back to client


### PR DESCRIPTION
Adds socket accept API
Adds context manager methods for socket
Adds setter for socket socknum
Adds status property for socket
Corrects bug in remote_port method

Tested with a SAMD51 running CircuitPython 6.0.0

CircuitPython test code:

```py
import time
import board
import busio
import digitalio
import adafruit_requests as requests
from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket

cs = digitalio.DigitalInOut(board.D5)
spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
eth = WIZNET5K(spi_bus, cs, is_dhcp=False, debug=False)

socket.set_interface(eth)
s = socket.socket()
HOST = '192.168.3.56'  # Standard loopback interface address (localhost)
PORT = 65432        # Port to listen on (non-privileged ports are > 1023)

s.bind((HOST, PORT)) # Bind to IP and Port
s.listen() # begin listening

while True:
    listen_status = eth.socket_status(s.socknum)
    conn, addr = s.accept()
    with conn:
        data = conn.recv()
        print(f"data is {data}")
        conn.send(data)
```

Python client test code:
```python 
import time
import socket

HOST = '192.168.3.56'  # The server's hostname or IP address
PORT = 65432        # The port used by the server
while True:

    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
        s.connect((HOST, PORT))
        s.sendall(b'Hello, world')
        data = s.recv(1024)
        print('Received', repr(data))
        time.sleep(1)


```