### PR TITLE
Socket improvements

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -760,13 +760,17 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
         while (
             self._read_socket(socket_num, REG_SNIR)[0] & SNIR_SEND_OK
         ) != SNIR_SEND_OK:
-            if self.socket_status(socket_num)[0] in (
-                SNSR_SOCK_CLOSED,
-                SNSR_SOCK_TIME_WAIT,
-                SNSR_SOCK_FIN_WAIT,
-                SNSR_SOCK_CLOSE_WAIT,
-                SNSR_SOCK_CLOSING,
-            ) or (timeout and time.monotonic() - stamp > timeout):
+            if (
+                self.socket_status(socket_num)[0]
+                in (
+                    SNSR_SOCK_CLOSED,
+                    SNSR_SOCK_TIME_WAIT,
+                    SNSR_SOCK_FIN_WAIT,
+                    SNSR_SOCK_CLOSE_WAIT,
+                    SNSR_SOCK_CLOSING,
+                )
+                or (timeout and time.monotonic() - stamp > timeout)
+            ):
                 # self.socket_close(socket_num)
                 return 0
             time.sleep(0.01)


### PR DESCRIPTION
- Fixed `socket_available` to just report and not flush available UDP
  data when calling multiple times.
- Fixed socket `__exit__` to only disconnect if a TCP (stream) socket.
- Connect can now accept domain names like CPython versus only IP
  addresses.
- Added socket `send_to`, `recvfrom`, `recv_into`, `recvfrom_into`
  methods for better compatibility with CPython socket.
- Simplified `recv` and `readline` socket methods due to
  `available` doing the right thing for both TCP and UDP.
- Reformatting to make black happy.
- Changes made and tested to make generic socket NTP implementation work:
  https://github.com/askpatrickw/Adafruit_CircuitPython_NTP/blob/raw_ntp/adafruit_ntp.py