### PR TITLE
Correct socket_open for UDP

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -610,6 +610,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
             SNSR_SOCK_FIN_WAIT,
             SNSR_SOCK_CLOSE_WAIT,
             SNSR_SOCK_CLOSING,
+            SNSR_SOCK_UDP,
         ):
             if self._debug:
                 print("* Opening W5k Socket, protocol={}".format(conn_mode))


### PR DESCRIPTION
Added `SNSR_SOCK_UDP` as a valid status condition in `socket_open` to correct bug with UDP sockets.