### PR TITLE
UDP server requires opening socket on chip during bind

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -553,7 +553,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
             print("Allocated socket #{}".format(sock))
         return sock
 
-    def socket_listen(self, socket_num, port):
+    def socket_listen(self, socket_num, port, conn_mode=SNMR_TCP):
         """Start listening on a socket (TCP mode only).
         :parm int socket_num: socket number
         :parm int port: port to listen on
@@ -567,7 +567,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
             )
         # Initialize a socket and set the mode
         self.src_port = port
-        res = self.socket_open(socket_num, conn_mode=SNMR_TCP)
+        res = self.socket_open(socket_num, conn_mode=conn_mode)
         self.src_port = 0
         if res == 1:
             raise RuntimeError("Failed to initalize the socket.")
@@ -575,10 +575,13 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
         self._send_socket_cmd(socket_num, CMD_SOCK_LISTEN)
         # Wait until ready
         status = [SNSR_SOCK_CLOSED]
-        while status[0] not in (SNSR_SOCK_LISTEN, SNSR_SOCK_ESTABLISHED):
+        while status[0] not in (SNSR_SOCK_LISTEN, SNSR_SOCK_ESTABLISHED, SNSR_SOCK_UDP):
             status = self._read_snsr(socket_num)
             if status[0] == SNSR_SOCK_CLOSED:
                 raise RuntimeError("Listening socket closed.")
+
+    def socket_listen_udp(self, socket_num, port):
+        self.socket_listen(socket_num, port, SNMR_UDP)
 
     def socket_accept(self, socket_num):
         """Gets the dest IP and port from an incoming connection.

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -554,7 +554,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
         return sock
 
     def socket_listen(self, socket_num, port, conn_mode=SNMR_TCP):
-        """Start listening on a socket (TCP mode only).
+        """Start listening on a socket (default TCP mode).
         :parm int socket_num: socket number
         :parm int port: port to listen on
         """
@@ -579,9 +579,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
             status = self._read_snsr(socket_num)
             if status[0] == SNSR_SOCK_CLOSED:
                 raise RuntimeError("Listening socket closed.")
-
-    def socket_listen_udp(self, socket_num, port):
-        self.socket_listen(socket_num, port, SNMR_UDP)
 
     def socket_accept(self, socket_num):
         """Gets the dest IP and port from an incoming connection.

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -315,7 +315,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
 
     @property
     def link_status(self):
-        """"Returns if the PHY is connected."""
+        """ "Returns if the PHY is connected."""
         if self._chip_type == "w5500":
             data = self.read(REG_PHYCFGR, 0x00)
             return data[0] & 0x01
@@ -557,6 +557,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
         """Start listening on a socket (default TCP mode).
         :parm int socket_num: socket number
         :parm int port: port to listen on
+        :parm int conn_mode: connection mode SNMR_TCP (default) or SNMR_UDP
         """
         assert self.link_status, "Ethernet cable disconnected!"
         if self._debug:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -181,6 +181,11 @@ class socket:
             if ip_address != current_ip:
                 _the_interface.ifconfig = (ip_address, subnet_mask, gw_addr, dns)
         self._listen_port = address[1]
+        # For UDP servers we need to open the socket here because we won't call 
+        # listen
+        if self._sock_type == SOCK_DGRAM:
+            _the_interface.socket_listen_udp(self.socknum, self._listen_port)
+            self._buffer = b""
 
     def listen(self, backlog=None):
         """Listen on the port specified by bind.

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -181,10 +181,12 @@ class socket:
             if ip_address != current_ip:
                 _the_interface.ifconfig = (ip_address, subnet_mask, gw_addr, dns)
         self._listen_port = address[1]
-        # For UDP servers we need to open the socket here because we won't call 
+        # For UDP servers we need to open the socket here because we won't call
         # listen
         if self._sock_type == SOCK_DGRAM:
-            _the_interface.socket_listen_udp(self.socknum, self._listen_port)
+            _the_interface.socket_listen(
+                self.socknum, self._listen_port, wiznet5k.adafruit_wiznet5k.SNMR_UDP
+            )
             self._buffer = b""
 
     def listen(self, backlog=None):


### PR DESCRIPTION
UDP server support requires the socket on the chip to be opened during
bind. For TCP the socket_listen function handles this and now bind calls
an equivalent socket_listen_udp if the socket type is SOCK_DGRAM.