### PR TITLE
Mask address to prevent rollover issues during socket.read() and socket.write()

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -802,11 +802,11 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
         return self._pbuff[0] << 8 | self._pbuff[1]
 
     def _write_snrx_rd(self, sock, data):
-        self._write_socket(sock, REG_SNRX_RD, data >> 8)
+        self._write_socket(sock, REG_SNRX_RD, data >> 8 & 0xFF)
         self._write_socket(sock, REG_SNRX_RD + 1, data & 0xFF)
 
     def _write_sntx_wr(self, sock, data):
-        self._write_socket(sock, REG_SNTX_WR, data >> 8)
+        self._write_socket(sock, REG_SNTX_WR, data >> 8 & 0xFF)
         self._write_socket(sock, REG_SNTX_WR + 1, data & 0xFF)
 
     def _read_sntx_wr(self, sock):


### PR DESCRIPTION
When testing I would occasionally get errors originating from the `socket.recv()` method traced down through `_write_snrx_rd` to `_write_socket()` where the address written was greater then 0xFFFF. 

I added masks for the two calls that could rollover per the W5500 datasheet, specifically point 3:
![image](https://user-images.githubusercontent.com/45793216/126524530-ce249b0f-18ee-4312-8692-3da1ea28b0be.png)
