### PR TITLE
change reset line transition

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -166,9 +166,9 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
 
         # reset wiznet module prior to initialization
         if reset:
-            reset.value = True
-            time.sleep(0.1)
             reset.value = False
+            time.sleep(0.1)
+            reset.value = True
             time.sleep(0.1)
 
         # Buffer for reading params from module


### PR DESCRIPTION
Resolves #51 

After testing, it seems no timing change is needed, only the order of the transition needed to change.

My test code revises the earlier gist to remove all external reset logic, and use GP20 as the reset line.

https://gist.github.com/chabala/e8cc48355c03a34c209dba43b03a5526

Also, would it be worthwhile to have this example code in-project rather than in gists?