### PR TITLE
Fix sending when offset+ret larger than sock size

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -830,10 +830,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
         ptr = (ptr + ret) & 0xFFFF
         self._write_sntx_wr(socket_num, ptr)
 
-        cntl_byte = 0x14 + (socket_num << 5)
-        txbuf = buffer[:ret]  # <- use ret
-        self.write(dst_addr, cntl_byte, txbuf)
-
         self._write_sncr(socket_num, CMD_SOCK_SEND)
         self._read_sncr(socket_num)
 


### PR DESCRIPTION
Hi!

I have noticed a bug in your library. It seems the code for writing data to the socket buffer was duplicated when support for the W5100s was introduced. Data is therefore written twice to the socket buffer.
This leads to mangled data whenever the current `buffer offset + size of the data to send` exceeds the total size of the socket buffer.

Example:
Current buffer offset is 2028.
Data to send is 50 bytes.
The first 20 bytes of our data fit into the socket buffer so they are written correctly. Afterwards the last 30 bytes of data are written to the beginning of the socket buffer, but are then again overwritten by the first 30 bytes of our data.

I have removed the duplicated writing of data in this PR.