### PR TITLE
Fixed the usage of int.from_bytes and int.to_bytes

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -859,7 +859,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             val_1 = self._read_snrx_rsr(sock)
             if val_1 != 0:
                 val = self._read_snrx_rsr(sock)
-        return int.from_bytes(val, "b")
+        return int.from_bytes(val, "big")
 
     def _get_tx_free_size(self, sock):
         """Get free size of sock's tx buffer block."""
@@ -869,7 +869,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             val_1 = self._read_sntx_fsr(sock)
             if val_1 != 0:
                 val = self._read_sntx_fsr(sock)
-        return int.from_bytes(val, "b")
+        return int.from_bytes(val, "big")
 
     def _read_snrx_rd(self, sock):
         self._pbuff[0] = self._read_socket(sock, REG_SNRX_RD)[0]

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -152,7 +152,7 @@ class DHCP:
 
         # Transaction ID (xid)
         self._initial_xid = htonl(self._transaction_id)
-        self._initial_xid = self._initial_xid.to_bytes(4, "l")
+        self._initial_xid = self._initial_xid.to_bytes(4, "big")
         _BUFF[4:7] = self._initial_xid
 
         # seconds elapsed
@@ -161,7 +161,7 @@ class DHCP:
 
         # flags
         flags = htons(0x8000)
-        flags = flags.to_bytes(2, "b")
+        flags = flags.to_bytes(2, "big")
         _BUFF[10] = flags[1]
         _BUFF[11] = flags[0]
 
@@ -259,7 +259,7 @@ class DHCP:
         if _BUFF[28:34] == 0:
             return 0, 0
 
-        if int.from_bytes(_BUFF[235:240], "l") != MAGIC_COOKIE:
+        if int.from_bytes(_BUFF[235:240], "big") != MAGIC_COOKIE:
             return 0, 0
 
         # -- Parse Packet, VARIABLE -- #
@@ -287,7 +287,7 @@ class DHCP:
                 ptr += 1
                 opt_len = _BUFF[ptr]
                 ptr += 1
-                self._lease_time = int.from_bytes(_BUFF[ptr : ptr + opt_len], "l")
+                self._lease_time = int.from_bytes(_BUFF[ptr : ptr + opt_len], "big")
                 ptr += opt_len
             elif _BUFF[ptr] == ROUTERS_ON_SUBNET:
                 ptr += 1
@@ -305,13 +305,13 @@ class DHCP:
                 ptr += 1
                 opt_len = _BUFF[ptr]
                 ptr += 1
-                self._t1 = int.from_bytes(_BUFF[ptr : ptr + opt_len], "l")
+                self._t1 = int.from_bytes(_BUFF[ptr : ptr + opt_len], "big")
                 ptr += opt_len
             elif _BUFF[ptr] == T2_VAL:
                 ptr += 1
                 opt_len = _BUFF[ptr]
                 ptr += 1
-                self._t2 = int.from_bytes(_BUFF[ptr : ptr + opt_len], "l")
+                self._t2 = int.from_bytes(_BUFF[ptr : ptr + opt_len], "big")
                 ptr += opt_len
             elif _BUFF[ptr] == 0:
                 break
@@ -399,7 +399,7 @@ class DHCP:
                 if msg_type == DHCP_OFFER:
                     # Check if transaction ID matches, otherwise it may be an offer
                     # for another device
-                    if htonl(self._transaction_id) == int.from_bytes(xid, "l"):
+                    if htonl(self._transaction_id) == int.from_bytes(xid, "big"):
                         if self._debug:
                             print(
                                 "* DHCP: Send request to {}".format(self.dhcp_server_ip)
@@ -423,7 +423,7 @@ class DHCP:
                 msg_type, xid = self.parse_dhcp_response()
                 # Check if transaction ID matches, otherwise it may be
                 # for another device
-                if htonl(self._transaction_id) == int.from_bytes(xid, "l"):
+                if htonl(self._transaction_id) == int.from_bytes(xid, "big"):
                     if msg_type == DHCP_ACK:
                         if self._debug:
                             print("* DHCP: Successful lease")

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -113,7 +113,7 @@ class DNS:
             print("DNS Packet Received: ", self._pkt_buf)
 
         # Validate request identifier
-        xid = int.from_bytes(self._pkt_buf[0:2], "l")
+        xid = int.from_bytes(self._pkt_buf[0:2], "big")
         if not xid == self._request_id:
             if self._debug:
                 print(
@@ -124,19 +124,19 @@ class DNS:
                 )
             return -1
         # Validate flags
-        flags = int.from_bytes(self._pkt_buf[2:4], "l")
+        flags = int.from_bytes(self._pkt_buf[2:4], "big")
         if not flags in (0x8180, 0x8580):
             if self._debug:
                 print("* DNS ERROR: Invalid flags, ", flags)
             return -1
         # Number of questions
-        qr_count = int.from_bytes(self._pkt_buf[4:6], "l")
+        qr_count = int.from_bytes(self._pkt_buf[4:6], "big")
         if not qr_count >= 1:
             if self._debug:
                 print("* DNS ERROR: Question count >=1, ", qr_count)
             return -1
         # Number of answers
-        an_count = int.from_bytes(self._pkt_buf[6:8], "l")
+        an_count = int.from_bytes(self._pkt_buf[6:8], "big")
         if self._debug:
             print("* DNS Answer Count: ", an_count)
         if not an_count >= 1:
@@ -156,7 +156,7 @@ class DNS:
             ptr += name_len + 1
 
         # Validate Query is Type A
-        q_type = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "l")
+        q_type = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "big")
         if not q_type == TYPE_A:
             if self._debug:
                 print("* DNS ERROR: Incorrect Query Type: ", q_type)
@@ -164,7 +164,7 @@ class DNS:
         ptr += 2
 
         # Validate Query is Type A
-        q_class = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "l")
+        q_class = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "big")
         if not q_class == TYPE_A:
             if self._debug:
                 print("* DNS ERROR: Incorrect Query Class: ", q_class)
@@ -181,7 +181,7 @@ class DNS:
         ptr += 1
 
         # Validate Answer Type A
-        ans_type = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "l")
+        ans_type = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "big")
         if not ans_type == TYPE_A:
             if self._debug:
                 print("* DNS ERROR: Incorrect Answer Type: ", ans_type)
@@ -189,7 +189,7 @@ class DNS:
         ptr += 2
 
         # Validate Answer Class IN
-        ans_class = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "l")
+        ans_class = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "big")
         if not ans_class == TYPE_A:
             if self._debug:
                 print("* DNS ERROR: Incorrect Answer Class: ", ans_class)
@@ -200,7 +200,7 @@ class DNS:
         ptr += 4
 
         # Validate addr is IPv4
-        data_len = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "l")
+        data_len = int.from_bytes(self._pkt_buf[ptr : ptr + 2], "big")
         if not data_len == DATA_LEN:
             if self._debug:
                 print("* DNS ERROR: Unexpected Data Length: ", data_len)


### PR DESCRIPTION
- Fixed the usage of `int.from_bytes` and `int.to_bytes` to pass the proper byteorder value. The correct values are `"big"` and `"little"` not `"b"` and `"l"`
- Fixed DHCP and DNS using little-endian instead of big-endian for parsing bytes. Network order of bytes is big endian, so DHCP was not working and DNS could not match the request ids because it was using `"l"` instead of `"big"`

Not sure how this was working before. Maybe older versions ignored the wrong parameters and used big-endian by default. Without this fix I could not get it to work on my board, I was always getting a `ValueError: Invalid byteorder` when doing DHCP.



This was tested with:
```
Adafruit CircuitPython 8.0.0-alpha.1-75-gec73ab841 on 2022-07-28; W5500-EVB-Pico with rp2040
Board ID:wiznet_w5500_evb_pico
```