### PR TITLE
Fixed buffer overrun in adafruit_wiznet5k_dhcp.send_dhcp_message (non breaking)

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -95,6 +95,10 @@ class DHCP:
     ):
         self._debug = debug
         self._response_timeout = response_timeout
+
+        # Prevent buffer overrun in send_dhcp_message()
+        if len(mac_address) != 6:
+            raise ValueError("The MAC address must be 6 bytes.")
         self._mac_address = mac_address
 
         # Set socket interface


### PR DESCRIPTION
closes #68 Check length of MAC address is 6 bytes in `DHCP.__init__()`

```
    def __init__(
        self, eth, mac_address, hostname=None, response_timeout=30, debug=False
        ...
                # Prevent buffer overrun in send_dhcp_message()
        if len(mac_address) != 6:
            raise ValueError("The MAC address must be 6 bytes.")
        self._mac_address = mac_address
```
N.B. I don't have hardware to test this.