### PR TITLE
Added typing

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -380,7 +380,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         if socket_num >= self.max_sockets:
             return self._pbuff
-        for octet in range(4):
+        for octet in range(0, 4):
             self._pbuff[octet] = self._read_socket(socket_num, REG_SNDIPR + octet)[0]
         return self.pretty_ip(self._pbuff)
 
@@ -1099,7 +1099,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
     def _write_sndipr(self, sock: int, ip_addr: bytearray) -> None:
         """Write to socket destination IP Address."""
-        for octet in range(4):
+        for octet in range(0, 4):
             self._write_socket(sock, REG_SNDIPR + octet, ip_addr[octet])
 
     def _write_sndport(self, sock: int, port: int) -> None:

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -645,7 +645,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
                 return ret
         return 0
 
-    def socket_status(self, socket_num: int) -> Union[bytearray, None]:
+    def socket_status(self, socket_num: int) -> Optional[bytearray]:
         """
         Return the socket connection status.
 
@@ -656,7 +656,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
         :param int socket_num: ID of socket to check.
 
-        :return: Union[bytearray, None]
+        :return: Optional[bytearray]
         """
         return self._read_snsr(socket_num)
 
@@ -1087,12 +1087,12 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         self._pbuff[1] = self._read_socket(sock, 0x0024 + 1)[0]
         return self._pbuff[0] << 8 | self._pbuff[1]
 
-    def _read_sntx_fsr(self, sock: int) -> Union[bytearray, None]:
+    def _read_sntx_fsr(self, sock: int) -> Optional[bytearray]:
         data = self._read_socket(sock, REG_SNTX_FSR)
         data += self._read_socket(sock, REG_SNTX_FSR + 1)
         return data
 
-    def _read_snrx_rsr(self, sock: int) -> Union[bytearray, None]:
+    def _read_snrx_rsr(self, sock: int) -> Optional[bytearray]:
         data = self._read_socket(sock, REG_SNRX_RSR)
         data += self._read_socket(sock, REG_SNRX_RSR + 1)
         return data
@@ -1107,7 +1107,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         self._write_socket(sock, REG_SNDPORT, port >> 8)
         self._write_socket(sock, REG_SNDPORT + 1, port & 0xFF)
 
-    def _read_snsr(self, sock: int) -> Union[bytearray, None]:
+    def _read_snsr(self, sock: int) -> Optional[bytearray]:
         """Read Socket n Status Register."""
         return self._read_socket(sock, REG_SNSR)
 
@@ -1127,10 +1127,10 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def _write_sncr(self, sock: int, data: int) -> None:
         self._write_socket(sock, REG_SNCR, data)
 
-    def _read_sncr(self, sock: int) -> Union[bytearray, None]:
+    def _read_sncr(self, sock: int) -> Optional[bytearray]:
         return self._read_socket(sock, REG_SNCR)
 
-    def _read_snmr(self, sock: int) -> Union[bytearray, None]:
+    def _read_snmr(self, sock: int) -> Optional[bytearray]:
         return self._read_socket(sock, REG_SNMR)
 
     def _write_socket(self, sock: int, address: int, data: int) -> None:
@@ -1145,7 +1145,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             )
         return None
 
-    def _read_socket(self, sock: int, address: int) -> Union[bytearray, None]:  # *1
+    def _read_socket(self, sock: int, address: int) -> Optional[bytearray]:  # *1
         """Read a W5k socket register."""
         if self._chip_type == "w5500":
             cntl_byte = (sock << 5) + 0x08

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -7,7 +7,6 @@
 # SPDX-FileCopyrightText: 2021 Adam Cummick
 #
 # SPDX-License-Identifier: MIT
-
 """
 `adafruit_wiznet5k`
 ================================================================================
@@ -129,23 +128,12 @@ W5200_W5500_MAX_SOCK_NUM = const(0x08)
 W5100_MAX_SOCK_NUM = const(0x04)
 SOCKET_INVALID = const(255)
 
-
 # Source ports in use
 SRC_PORTS = [0] * W5200_W5500_MAX_SOCK_NUM
 
 
 class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-attributes
-    """Interface for WIZNET5K module.
-
-    :param ~busio.SPI spi_bus: The SPI bus the Wiznet module is connected to.
-    :param ~digitalio.DigitalInOut cs: Chip select pin.
-    :param ~digitalio.DigitalInOut reset: Optional reset pin.
-    :param bool is_dhcp: Whether to start DHCP automatically or not.
-    :param Union[List[int], Tuple[int]] mac: The Wiznet's MAC Address.
-    :param str hostname: The desired hostname, with optional {} to fill in MAC.
-    :param float dhcp_timeout: Timeout in seconds for DHCP response.
-    :param bool debug: Enable debugging output.
-    """
+    """Interface for WIZNET5K module."""
 
     TCP_MODE = const(0x21)
     UDP_MODE = const(0x02)
@@ -163,6 +151,18 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         dhcp_timeout: float = 30,
         debug: bool = False,
     ) -> None:
+        """
+        :param busio.SPI spi_bus: The SPI bus the Wiznet module is connected to.
+        :param digitalio.DigitalInOut cs: Chip select pin.
+        :param digitalio.DigitalInOut reset: Optional reset pin, defaults to None.
+        :param bool is_dhcp: Whether to start DHCP automatically or not, defaults to True.
+        :param Union[List[int], Tuple[int]] mac: The Wiznet's MAC Address, defaults to
+            (0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED).
+        :param str hostname: The desired hostname, with optional {} to fill in the MAC
+            address, defaults to None.
+        :param float dhcp_timeout: Timeout in seconds for DHCP response, defaults to 30.
+        :param bool debug: Enable debugging output, defaults to False.
+        """
         self._debug = debug
         self._chip_type = None
         self._device = SPIDevice(spi_bus, cs, baudrate=8000000, polarity=0, phase=0)
@@ -214,12 +214,15 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def set_dhcp(
         self, hostname: Optional[str] = None, response_timeout: float = 30
     ) -> int:
-        """Initializes the DHCP client and attempts to retrieve
-        and set network configuration from the DHCP server.
-        Returns 0 if DHCP configured, -1 otherwise.
+        """Initialize the DHCP client and attempt to retrieve and set network
+        configuration from the DHCP server.
 
-        :param str hostname: The desired hostname, with optional {} to fill in MAC.
-        :param float response_timeout: Time to wait for server to return packet, in seconds.
+        :param str hostname: The desired hostname for the DHCP server with optional {} to
+            fill in the MAC address, defaults to None.
+        :param float response_timeout: Time to wait for server to return packet in seconds,
+            defaults to 30.
+
+        :return: 0 if DHCP configured, -1 otherwise.
         """
         if self._debug:
             print("* Initializing DHCP")
@@ -242,11 +245,11 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return -1
 
     def maintain_dhcp_lease(self) -> None:
-        """Maintain DHCP lease"""
+        """Maintain the DHCP lease."""
         if self._dhcp_client is not None:
             self._dhcp_client.maintain_dhcp_lease()
 
-    def get_host_by_name(self, hostname: str) -> bytearray:
+    def get_host_by_name(self, hostname: str) -> bytearray:  # TODO: ****
         """Convert a hostname to a packed 4-byte IP Address.
         Returns a 4 bytearray.
         """

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -26,6 +26,10 @@ Implementation Notes
 
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
+
+__version__ = "0.0.0+auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k.git"
+
 # pylint: disable=too-many-lines
 try:
     from typing import Optional, Union, List, Tuple, Sequence
@@ -42,11 +46,6 @@ from micropython import const
 from adafruit_bus_device.spi_device import SPIDevice
 import adafruit_wiznet5k.adafruit_wiznet5k_dhcp as dhcp
 import adafruit_wiznet5k.adafruit_wiznet5k_dns as dns
-
-
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k.git"
-
 
 # Wiznet5k Registers
 REG_MR = const(0x0000)  # Mode
@@ -223,7 +222,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :param Optional[str] hostname: The desired hostname for the DHCP server with optional {} to
             fill in the MAC address, defaults to None.
         :param float response_timeout: Time to wait for server to return packet in seconds,
-            defaults to 30.
+            defaults to 30.0.
 
         :return int: 0 if DHCP configured, -1 otherwise.
         """
@@ -359,7 +358,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :param bytearray mac: The MAC address.
 
         :return str: Mac Address in the form 00:00:00:00:00:00
-
         """
         return "%s:%s:%s:%s:%s:%s" % (
             hex(mac[0]),
@@ -420,7 +418,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         Network configuration information.
 
         :return Tuple[bytearray, bytearray, bytearray, Tuple[int, int, int, int]]: \
-        The IP address, subnet mask, gateway address and DNS server address."""
+            The IP address, subnet mask, gateway address and DNS server address."""
         return (
             self.ip_address,
             self.read(REG_SUBR, 0x00, 4),
@@ -435,8 +433,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         Set network configuration.
 
-        :params Tuple[bytearray, bytearray, bytearray, Tuple[int, int, int, int]]: \
-        Configuration settings - (ip_address, subnet_mask, gateway_address, dns_server).
+        :param Tuple[bytearray, bytearray, bytearray, Tuple[int, int, int, int]]:
+            Configuration settings - (ip_address, subnet_mask, gateway_address, dns_server).
         """
         ip_address, subnet_mask, gateway_address, dns_server = params
 
@@ -606,12 +604,11 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
     def socket_available(self, socket_num: int, sock_type: int = SNMR_TCP) -> int:
         """
-        Return the number of bytes available to be read from the socket.
+        Number of bytes available to be read from the socket.
 
         :param int socket_num: Socket to check for available bytes.
         :param int sock_type: Socket type. Use SNMR_TCP for TCP or SNMR_UDP for UDP, \
-        defaults to SNMR_TCP.
-
+            defaults to SNMR_TCP.
         :return int: Number of bytes available to read.
         """
         if self._debug:
@@ -642,7 +639,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
     def socket_status(self, socket_num: int) -> Optional[bytearray]:
         """
-        Return the socket connection status.
+        Socket connection status.
 
         Can be: SNSR_SOCK_CLOSED, SNSR_SOCK_INIT, SNSR_SOCK_LISTEN, SNSR_SOCK_SYNSENT,
         SNSR_SOCK_SYNRECV, SNSR_SYN_SOCK_ESTABLISHED, SNSR_SOCK_FIN_WAIT,
@@ -671,7 +668,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :param Union[bytes, bytearray] dest: The destination as a host name or IP address.
         :param int port: Port to connect to (0 - 65,536).
         :param int conn_mode: The connection mode. Use SNMR_TCP for TCP or SNMR_UDP for UDP,
-        defaults to SNMR_TCP.
+            defaults to SNMR_TCP.
         """
         assert self.link_status, "Ethernet cable disconnected!"
         if self._debug:
@@ -712,7 +709,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def get_socket(self) -> int:
         """Request, allocate and return a socket from the W5k chip.
 
-        Cycles through the sockets to find the first available one, if any.
+        Cycle through the sockets to find the first available one, if any.
 
         :return int: The first available socket. Returns 0xFF if no sockets are free.
         """
@@ -773,7 +770,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         the IP address and port of the incoming connection.
 
         :param int socket_num: Socket number with connection to check.
-
         :return Tuple[int, Tuple[Union[str, bytearray], Union[int, bytearray]]]:
             If successful, the next (socket number, (destination IP address, destination port)).
 
@@ -799,8 +795,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
         :param int socket_num: The socket number to open.
         :param int conn_mode: The protocol to use. Use SNMR_TCP for TCP or SNMR_UDP for \
-        UDP, defaults to SNMR_TCP.
-
+            UDP, defaults to SNMR_TCP.
         :return int: 1 if the socket was opened, 0 if not.
         """
         assert self.link_status, "Ethernet cable disconnected!"
@@ -874,9 +869,9 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :param int length: The number of bytes to read from the socket.
 
         :return Tuple[int, Union[int, bytearray]]: If the read was successful then the first
-        item of the tuple is the length of the data and the second is the data. If the read
-        was unsuccessful then both items equal an error code, 0 for no data waiting and -1
-        for no connection to the socket.
+            item of the tuple is the length of the data and the second is the data. If the read
+            was unsuccessful then both items equal an error code, 0 for no data waiting and -1
+            for no connection to the socket.
         """
         assert self.link_status, "Ethernet cable disconnected!"
         assert socket_num <= self.max_sockets, "Provided socket exceeds max_sockets."

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -289,7 +289,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         Ethernet controller chip type.
 
-        :return str: The chip type."""
+        :return str: The chip type.
+        """
         return self._chip_type
 
     @property
@@ -297,7 +298,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         Configured IP address.
 
-        :return bytearray.
+        :return bytearray: IP address as four bytes.
         """
         return self.read(REG_SIPR, 0x00, 4)
 
@@ -307,7 +308,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         ip: bytearray,
     ) -> str:
         """
-        Convert a bytearray IP address to a dotted-quad string for printing.
+        Convert a 4 byte IP address to a dotted-quad string for printing.
 
         :param bytearray ip: A four byte IP address.
 
@@ -323,9 +324,9 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         Convert a dotted-quad string to a four byte IP address.
 
-        :param str ip: The IP address (a string of the form '255.255.255.255') to be converted.
+        :param str ip: IP address (a string of the form '255.255.255.255') to be converted.
 
-        :return bytes: The IP address in four bytes.
+        :return bytes: IP address in four bytes.
         """
         octets = [int(x) for x in ip.split(".")]
         return bytes(octets)
@@ -335,7 +336,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         Ethernet hardware's MAC address.
 
-        :return bytearray: The six byte MAC address."""
+        :return bytearray: Six byte MAC address."""
         return self.read(REG_SHAR, 0x00, 6)
 
     @mac_address.setter
@@ -374,7 +375,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
         :param int socket_num: ID number of the socket to check.
 
-        :return Union[str, bytearray]: The four byte IP address.
+        :return Union[str, bytearray]: A four byte IP address.
         """
         if socket_num >= self.max_sockets:
             return self._pbuff
@@ -553,7 +554,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :param int length: Number of bytes to read from the register, defaults to 1.
         :param Optional[WriteableBuffer] buffer: Buffer to read data into, defaults to None.
 
-        :return Union[WriteableBuffer, bytearray]: The data read from the chip.
+        :return Union[WriteableBuffer, bytearray]: Data read from the chip.
         """
         with self._device as bus_device:
             if self._chip_type == "w5500":
@@ -609,6 +610,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :param int socket_num: Socket to check for available bytes.
         :param int sock_type: Socket type. Use SNMR_TCP for TCP or SNMR_UDP for UDP, \
             defaults to SNMR_TCP.
+
         :return int: Number of bytes available to read.
         """
         if self._debug:

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -216,7 +216,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def set_dhcp(
         self, hostname: Optional[str] = None, response_timeout: float = 30
     ) -> int:
-        """Initialize the DHCP client and attempt to retrieve and set network
+        """
+        Initialize the DHCP client and attempt to retrieve and set network
         configuration from the DHCP server.
 
         :param Optional[str] hostname: The desired hostname for the DHCP server with optional {} to
@@ -252,7 +253,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             self._dhcp_client.maintain_dhcp_lease()
 
     def get_host_by_name(self, hostname: str) -> bytes:
-        """Convert a hostname to a packed 4-byte IP Address.
+        """
+        Convert a hostname to a packed 4-byte IP Address.
 
         :param str hostname: The host name to be converted.
 
@@ -272,7 +274,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
     @property
     def max_sockets(self) -> int:
-        """Maximum number of sockets supported by chip.
+        """
+        Maximum number of sockets supported by chip.
 
         :return int: Maximum supported sockets.
         """
@@ -1054,12 +1057,12 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         self._pbuff[1] = self._read_socket(sock, 0x0024 + 1)[0]
         return self._pbuff[0] << 8 | self._pbuff[1]
 
-    def _read_sntx_fsr(self, sock: int) -> Optional[bytearray]:
+    def _read_sntx_fsr(self, sock: int) -> Union[bytearray, None]:
         data = self._read_socket(sock, REG_SNTX_FSR)
         data += self._read_socket(sock, REG_SNTX_FSR + 1)
         return data
 
-    def _read_snrx_rsr(self, sock: int) -> Optional[bytearray]:
+    def _read_snrx_rsr(self, sock: int) -> Union[bytearray, None]:
         data = self._read_socket(sock, REG_SNRX_RSR)
         data += self._read_socket(sock, REG_SNRX_RSR + 1)
         return data
@@ -1074,7 +1077,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         self._write_socket(sock, REG_SNDPORT, port >> 8)
         self._write_socket(sock, REG_SNDPORT + 1, port & 0xFF)
 
-    def _read_snsr(self, sock: int) -> Optional[bytearray]:
+    def _read_snsr(self, sock: int) -> Union[bytearray, None]:
         """Reads Socket n Status Register."""
         return self._read_socket(sock, REG_SNSR)
 
@@ -1094,13 +1097,13 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def _write_sncr(self, sock: int, data: int) -> None:
         self._write_socket(sock, REG_SNCR, data)
 
-    def _read_sncr(self, sock: int) -> Optional[bytearray]:
+    def _read_sncr(self, sock: int) -> Union[bytearray, None]:
         return self._read_socket(sock, REG_SNCR)
 
-    def _read_snmr(self, sock: int) -> Optional[bytearray]:
+    def _read_snmr(self, sock: int) -> Union[bytearray, None]:
         return self._read_socket(sock, REG_SNMR)
 
-    def _write_socket(self, sock: int, address: int, data: int) -> None:  # 1*
+    def _write_socket(self, sock: int, address: int, data: int) -> None:
         """Write to a W5k socket register."""
         if self._chip_type == "w5500":
             cntl_byte = (sock << 5) + 0x0C

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -150,7 +150,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         is_dhcp: bool = True,
         mac: Union[List[int], Tuple[int]] = DEFAULT_MAC,
         hostname: Optional[str] = None,
-        dhcp_timeout: float = 30,
+        dhcp_timeout: float = 30.0,
         debug: bool = False,
     ) -> None:
         """
@@ -162,7 +162,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             (0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED).
         :param str hostname: The desired hostname, with optional {} to fill in the MAC
             address, defaults to None.
-        :param float dhcp_timeout: Timeout in seconds for DHCP response, defaults to 30.
+        :param float dhcp_timeout: Timeout in seconds for DHCP response, defaults to 30.0.
         :param bool debug: Enable debugging output, defaults to False.
         """
         self._debug = debug
@@ -406,7 +406,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
         :return Union[int, bytearray]: The port number of the socket connection.
         """
-        # TODO: why return the buffer?
         if socket_num >= self.max_sockets:
             return self._pbuff
         for octet in range(2):
@@ -439,7 +438,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :params Tuple[bytearray, bytearray, bytearray, Tuple[int, int, int, int]]: \
         Configuration settings - (ip_address, subnet_mask, gateway_address, dns_server).
         """
-        # TODO: Might be better if params can be str as well
         ip_address, subnet_mask, gateway_address, dns_server = params
 
         self.write(REG_SIPR, 0x04, ip_address)
@@ -455,7 +453,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :return int: 1 if the initialization succeeds, 0 if it fails.
         """
         time.sleep(1)
-        # TODO: Isn't the CS pin initialized in busio?
         self._cs.switch_to_output()
         self._cs.value = 1
 
@@ -525,7 +522,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
         :return int: 0 if the reset succeeds, -1 if not.
         """
-        # TODO: mode_reg appears to be unused, maybe self._read_mr starts the reset?
         mode_reg = self._read_mr()
         self._write_mr(0x80)
         mode_reg = self._read_mr()
@@ -589,7 +585,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :param int callback: Callback reference.
         :param Union[int, Sequence[Union[int, bytes]]] data: Data to write to the register address.
         """
-        # TODO: Call with int means an error in a previous function
         with self._device as bus_device:
             if self._chip_type == "w5500":
                 bus_device.write(bytes([addr >> 8]))  # pylint: disable=no-member
@@ -688,7 +683,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         # initialize a socket and set the mode
         res = self.socket_open(socket_num, conn_mode=conn_mode)
         if res == 1:
-            raise RuntimeError("Failed to initalize a connection with the socket.")
+            raise RuntimeError("Failed to initialize a connection with the socket.")
 
         # set socket destination IP and port
         self._write_sndipr(socket_num, dest)
@@ -758,7 +753,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         res = self.socket_open(socket_num, conn_mode=conn_mode)
         self.src_port = 0
         if res == 1:
-            raise RuntimeError("Failed to initalize the socket.")
+            raise RuntimeError("Failed to initialize the socket.")
         # Send listen command
         self._send_socket_cmd(socket_num, CMD_SOCK_LISTEN)
         # Wait until ready
@@ -979,7 +974,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         assert socket_num <= self.max_sockets, "Provided socket exceeds max_sockets."
         status = 0
         ret = 0
-        free_size = 0  # TODO: Bug report
+        free_size = 0
         if len(buffer) > SOCK_SIZE:
             ret = SOCK_SIZE
         else:
@@ -1020,7 +1015,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
                 dst_addr = socket_num * SOCK_SIZE + 0x4000
                 self.write(dst_addr, 0x00, txbuf)
             else:
-                txbuf = buffer[:ret]  # TODO: Bug report
+                txbuf = buffer[:ret]
                 self.write(dst_addr, 0x00, buffer[:ret])
 
         # update sn_tx_wr to the value + data size
@@ -1153,5 +1148,4 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         if self._chip_type == "w5100s":
             cntl_byte = 0
             return self.read(self._ch_base_msb + sock * CH_SIZE + address, cntl_byte)
-        # TODO: If the chip is not supported, this should raise an exception.
         return None

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -487,7 +487,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         callback: int,
         length: int = 1,
         buffer: Optional[WriteableBuffer] = None,
-    ) -> Union[WriteableBuffer, bytearray]:
+    ) -> Union[WriteableBuffer, bytearray]:  # TODO: Try a TypeVar
         """Reads data from a register address.
 
         :param int addr: Register address.

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -287,14 +287,16 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
     @property
     def chip(self) -> str:
-        """Ethernet controller chip type.
+        """
+        Ethernet controller chip type.
 
         :return str: The chip type."""
         return self._chip_type
 
     @property
     def ip_address(self) -> bytearray:
-        """Configured IP address.
+        """
+        Configured IP address.
 
         :return bytearray.
         """
@@ -305,11 +307,12 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         # pylint: disable=no-self-use, invalid-name
         ip: bytearray,
     ) -> str:
-        """Convert a bytearray IP address to a dotted-quad string for printing.
+        """
+        Convert a bytearray IP address to a dotted-quad string for printing.
 
         :param bytearray ip: A four byte IP address.
 
-        :return str: The IP address in 0.0.0.0 format.
+        :return str: The IP address (a string of the form '255.255.255.255').
         """
         return "%d.%d.%d.%d" % (ip[0], ip[1], ip[2], ip[3])
 
@@ -318,9 +321,10 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         # pylint: disable=no-self-use, invalid-name
         ip: str,
     ) -> bytes:
-        """Convert a dotted-quad string to a four byte IP address.
+        """
+        Convert a dotted-quad string to a four byte IP address.
 
-        :param str ip: The IP address in the form 0.0.0.0 to be converted.
+        :param str ip: The IP address (a string of the form '255.255.255.255') to be converted.
 
         :return bytes: The IP address in four bytes.
         """
@@ -329,14 +333,16 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
     @property
     def mac_address(self) -> bytearray:
-        """Ethernet hardware's MAC address.
+        """
+        Ethernet hardware's MAC address.
 
         :return bytearray: The six byte MAC address."""
         return self.read(REG_SHAR, 0x00, 6)
 
     @mac_address.setter
     def mac_address(self, address: Sequence[Union[int, bytes]]) -> None:
-        """Sets the hardware MAC address.
+        """
+        Sets the hardware MAC address.
 
         :param tuple address: Hardware MAC address.
         """
@@ -347,8 +353,12 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         # pylint: disable=no-self-use, invalid-name
         mac: bytearray,
     ) -> str:
-        """Converts a bytearray MAC address to a
-        dotted-quad string for printing
+        """
+        Convert a bytearray MAC address to a ':' seperated string for display.
+
+        :param bytearray mac: The MAC address.
+
+        :return str: Mac Address in the form 00:00:00:00:00:00
 
         """
         return "%s:%s:%s:%s:%s:%s" % (
@@ -361,7 +371,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         )
 
     def remote_ip(self, socket_num: int) -> Union[str, bytearray]:
-        """IP address of the host which sent the current incoming packet.
+        """
+        IP address of the host which sent the current incoming packet.
 
         :param int socket_num: ID number of the socket to check.
 
@@ -388,7 +399,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return 0
 
     def remote_port(self, socket_num: int) -> Union[int, bytearray]:
-        """Port of the host which sent the current incoming packet.
+        """
+        Port of the host which sent the current incoming packet.
 
         :param int socket_num: ID number of the socket to check.
 
@@ -405,7 +417,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def ifconfig(
         self,
     ) -> Tuple[bytearray, bytearray, bytearray, Tuple[int, int, int, int]]:  # *1
-        """Network configuration information.
+        """
+        Network configuration information.
 
         :return Tuple[bytearray, bytearray, bytearray, Tuple[int, int, int, int]]: \
         The IP address, subnet mask, gateway address and DNS server address."""
@@ -420,7 +433,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def ifconfig(
         self, params: Tuple[bytearray, bytearray, bytearray, Tuple[int, int, int, int]]
     ) -> None:
-        """Set network configuration.
+        """
+        Set network configuration.
 
         :params Tuple[bytearray, bytearray, bytearray, Tuple[int, int, int, int]]: \
         Configuration settings - (ip_address, subnet_mask, gateway_address, dns_server).
@@ -435,7 +449,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         self._dns = dns_server
 
     def _w5100_init(self) -> int:
-        """Detects and initializes a Wiznet5k ethernet module.
+        """
+        Detect and initialize a Wiznet5k ethernet module.
 
         :return int: 1 if the initialization succeeds, 0 if it fails.
         """
@@ -460,7 +475,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return 1
 
     def detect_w5500(self) -> int:
-        """Detects W5500 chip.
+        """
+        Detect W5500 chip.
 
         :return int: 1 if a W5500 chip is detected, -1 if not.
         """
@@ -488,7 +504,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return 1
 
     def detect_w5100s(self) -> int:
-        """Detects W5100S chip.
+        """
+        Detect W5100S chip.
 
         :return int: 1 if a W5100 chip is detected, -1 if not.
         """
@@ -502,8 +519,9 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return 1
 
     def sw_reset(self) -> int:
-        """Perform a soft-reset on the Wiznet chip
-        by writing to its MR register reset bit.
+        """Perform a soft-reset on the Wiznet chip.
+
+        Perform a soft reset by writing to the chip's MR register reset bit.
 
         :return int: 0 if the reset succeeds, -1 if not.
         """
@@ -518,12 +536,12 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return 0
 
     def _read_mr(self) -> bytearray:
-        """Reads from the Mode Register (MR)."""
+        """Read from the Mode Register (MR)."""
         res = self.read(REG_MR, 0x00)
         return res
 
     def _write_mr(self, data: int) -> None:
-        """Writes to the mode register (MR)."""
+        """Write to the mode register (MR)."""
         self.write(REG_MR, 0x04, data)
 
     def read(
@@ -533,7 +551,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         length: int = 1,
         buffer: Optional[WriteableBuffer] = None,
     ) -> Union[WriteableBuffer, bytearray]:
-        """Read data from a register address.
+        """
+        Read data from a register address.
 
         :param int addr: Register address to read.
         :param int callback: Callback reference.
@@ -563,7 +582,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def write(
         self, addr: int, callback: int, data: Union[int, Sequence[Union[int, bytes]]]
     ) -> None:
-        """Write data to a register address.
+        """
+        Write data to a register address.
 
         :param int addr: Destination address.
         :param int callback: Callback reference.
@@ -590,7 +610,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     # Socket-Register API
 
     def socket_available(self, socket_num: int, sock_type: int = SNMR_TCP) -> int:
-        """Return the number of bytes available to be read from the socket.
+        """
+        Return the number of bytes available to be read from the socket.
 
         :param int socket_num: Socket to check for available bytes.
         :param int sock_type: Socket type. Use SNMR_TCP for TCP or SNMR_UDP for UDP, \
@@ -625,7 +646,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return 0
 
     def socket_status(self, socket_num: int) -> Union[bytearray, None]:
-        """Returns the socket connection status.
+        """
+        Return the socket connection status.
 
         Can be: SNSR_SOCK_CLOSED, SNSR_SOCK_INIT, SNSR_SOCK_LISTEN, SNSR_SOCK_SYNSENT,
         SNSR_SOCK_SYNRECV, SNSR_SYN_SOCK_ESTABLISHED, SNSR_SOCK_FIN_WAIT,
@@ -645,7 +667,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         port: int,
         conn_mode: int = SNMR_TCP,
     ) -> int:
-        """Open and verify a connection from a socket to a destination IP address
+        """
+        Open and verify a connection from a socket to a destination IP address
         or hostname. A TCP connection is made by default. A UDP connection can also
         be made.
 
@@ -692,8 +715,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
                 print("waiting for sncr to clear...")
 
     def get_socket(self) -> int:
-        """Requests, allocates and returns a socket from the W5k
-        chip.
+        """Request, allocate and return a socket from the W5k chip.
 
         Cycles through the sockets to find the first available one, if any.
 
@@ -716,7 +738,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def socket_listen(
         self, socket_num: int, port: int, conn_mode: int = SNMR_TCP
     ) -> None:
-        """Start listening on a socket's port.
+        """
+        Listen on a socket's port.
 
         :param int socket_num: ID of socket to listen on.
         :param int port: Port to listen on (0 - 65,535).
@@ -748,15 +771,16 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def socket_accept(
         self, socket_num: int
     ) -> Tuple[int, Tuple[Union[str, bytearray], Union[int, bytearray]]]:
-        """Gets the dest IP and port from an incoming connection.
+        """
+        Destination IP address and port from an incoming connection.
 
-        Returns the next socket number so listening can continue, along with
+        Return the next socket number so listening can continue, along with
         the IP address and port of the incoming connection.
 
         :param int socket_num: Socket number with connection to check.
 
         :return Tuple[int, Tuple[Union[str, bytearray], Union[int, bytearray]]]:
-        If successful, the next (socket number, (destination IP address, destination port)).
+            If successful, the next (socket number, (destination IP address, destination port)).
 
         If errors occur, the destination IP address and / or the destination port may be
         returned as bytearrays.
@@ -773,7 +797,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return next_socknum, (dest_ip, dest_port)
 
     def socket_open(self, socket_num: int, conn_mode: int = SNMR_TCP) -> int:
-        """Opens a network socket.
+        """
+        Open an IP socket.
 
         The socket may connect via TCP or UDP protocols.
 
@@ -823,7 +848,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return 1
 
     def socket_close(self, socket_num: int) -> None:
-        """Close a socket.
+        """
+        Close a socket.
 
         :param int socket_num: The socket to close.
         """
@@ -833,7 +859,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         self._read_sncr(socket_num)
 
     def socket_disconnect(self, socket_num: int) -> None:
-        """Disconnect a TCP or UDP connection.
+        """
+        Disconnect a TCP or UDP connection.
 
         :param int socket_num: The socket to close.
         """
@@ -845,7 +872,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def socket_read(
         self, socket_num: int, length: int
     ) -> Tuple[int, Union[int, bytearray]]:
-        """Read data from a TCP socket.
+        """
+        Read data from a TCP socket.
 
         :param int socket_num: The socket to read data from.
         :param int length: The number of bytes to read from the socket.
@@ -915,7 +943,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def read_udp(
         self, socket_num: int, length: int
     ) -> Union[int, Tuple[int, Union[int, bytearray]]]:
-        """Read UDP socket's current message bytes.
+        """
+        Read UDP socket's current message bytes.
 
         :param int socket_num: The socket to read data from.
         :param int length: The number of bytes to read from the socket.
@@ -938,7 +967,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def socket_write(
         self, socket_num: int, buffer: bytearray, timeout: float = 0
     ) -> int:
-        """Write data to a socket.
+        """
+        Write data to a socket.
 
         :param int socket_num: The socket to write to.
         :param bytearray buffer: The data to write to the socket.
@@ -1020,7 +1050,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
     # Socket-Register Methods
     def _get_rx_rcv_size(self, sock: int) -> int:
-        """Get size of received and saved in socket buffer."""
+        """Size of received and saved in socket buffer."""
         val = 0
         val_1 = self._read_snrx_rsr(sock)
         while val != val_1:
@@ -1030,7 +1060,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return int.from_bytes(val, "big")
 
     def _get_tx_free_size(self, sock: int) -> int:
-        """Get free size of socket's tx buffer block."""
+        """Free size of socket's tx buffer block."""
         val = 0
         val_1 = self._read_sntx_fsr(sock)
         while val != val_1:
@@ -1068,17 +1098,17 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         return data
 
     def _write_sndipr(self, sock: int, ip_addr: bytearray) -> None:
-        """Writes to socket destination IP Address."""
+        """Write to socket destination IP Address."""
         for octet in range(4):
             self._write_socket(sock, REG_SNDIPR + octet, ip_addr[octet])
 
     def _write_sndport(self, sock: int, port: int) -> None:
-        """Writes to socket destination port."""
+        """Write to socket destination port."""
         self._write_socket(sock, REG_SNDPORT, port >> 8)
         self._write_socket(sock, REG_SNDPORT + 1, port & 0xFF)
 
     def _read_snsr(self, sock: int) -> Union[bytearray, None]:
-        """Reads Socket n Status Register."""
+        """Read Socket n Status Register."""
         return self._read_socket(sock, REG_SNSR)
 
     def _write_snmr(self, sock: int, protocol: int) -> None:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -254,7 +254,7 @@ class DHCP:
     # pylint: disable=too-many-branches, too-many-statements
     def parse_dhcp_response(
         self,
-    ) -> Union[Tuple[int, bytes], Tuple[int, int]]:  # TODO: ****
+    ) -> Union[Tuple[int, bytes], Tuple[int, int]]:
         """Parse DHCP response from DHCP server.
 
         :return Union[Tuple[int, bytes], Tuple[int, int]]: DHCP packet type.
@@ -272,13 +272,11 @@ class DHCP:
             DHCP message OP is not expected BOOT Reply."
 
         xid = _BUFF[4:8]
-        # TODO: ValueError bytes & int
         if bytes(xid) < self._initial_xid:
             print("f")
             return 0, 0
 
         self.local_ip = tuple(_BUFF[16:20])
-        # TODO: Don't think this will ever be True
         if _BUFF[28:34] == 0:
             return 0, 0
 
@@ -424,7 +422,6 @@ class DHCP:
                 if msg_type == DHCP_OFFER:
                     # Check if transaction ID matches, otherwise it may be an offer
                     # for another device
-                    # TODO: xid is already an int
                     if htonl(self._transaction_id) == int.from_bytes(xid, "big"):
                         if self._debug:
                             print(
@@ -449,7 +446,6 @@ class DHCP:
                 msg_type, xid = self.parse_dhcp_response()
                 # Check if transaction ID matches, otherwise it may be
                 # for another device
-                # TODO: xid is already an int
                 if htonl(self._transaction_id) == int.from_bytes(xid, "big"):
                     if msg_type == DHCP_ACK:
                         if self._debug:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -15,7 +15,9 @@ Pure-Python implementation of Jordan Terrell's DHCP library v0.3
 """
 try:
     from typing import Optional, Union, List, Tuple
-    from adafruit_wiznet5k import WIZNET5K
+
+    # pylint: disable=cyclic-import
+    from adafruit_wiznet5k import adafruit_wiznet5k
 except ImportError:
     pass
 
@@ -98,12 +100,13 @@ class DHCP:
     # pylint: disable=too-many-arguments, too-many-instance-attributes, invalid-name
     def __init__(
         self,
-        eth: WIZNET5K,
+        eth: adafruit_wiznet5k.WIZNET5K,
         mac_address: Union[List[int], Tuple[int]],
         hostname: Optional[str] = None,
         response_timeout: float = 30,
         debug: bool = False,
     ) -> None:
+
         self._debug = debug
         self._response_timeout = response_timeout
         self._mac_address = mac_address

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -253,7 +253,9 @@ class DHCP:
         self._sock.send(_BUFF)
 
     # pylint: disable=too-many-branches, too-many-statements
-    def parse_dhcp_response(self) -> Tuple[int, int]:
+    def parse_dhcp_response(
+        self,
+    ) -> Union[Tuple[int, bytes], Tuple[int, int]]:  # TODO: ****
         """Parse DHCP response from DHCP server.
         Returns DHCP packet type.
         """
@@ -420,6 +422,7 @@ class DHCP:
                 if msg_type == DHCP_OFFER:
                     # Check if transaction ID matches, otherwise it may be an offer
                     # for another device
+                    # TODO: xid is already an int
                     if htonl(self._transaction_id) == int.from_bytes(xid, "big"):
                         if self._debug:
                             print(
@@ -444,6 +447,7 @@ class DHCP:
                 msg_type, xid = self.parse_dhcp_response()
                 # Check if transaction ID matches, otherwise it may be
                 # for another device
+                # TODO: xid is already an int
                 if htonl(self._transaction_id) == int.from_bytes(xid, "big"):
                     if msg_type == DHCP_ACK:
                         if self._debug:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -87,15 +87,7 @@ _BUFF = bytearray(318)
 
 
 class DHCP:
-    """W5k DHCP Client implementation.
-
-    :param WIZNET5K eth: Wiznet 5k object
-    :param Union[List[int], Tuple[int]] mac_address: Hardware MAC.
-    :param str hostname: The desired hostname, with optional {} to fill in MAC.
-    :param float response_timeout: DHCP Response timeout.
-    :param bool debug: Enable debugging output.
-
-    """
+    """W5k DHCP Client implementation."""
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes, invalid-name
     def __init__(
@@ -106,7 +98,14 @@ class DHCP:
         response_timeout: float = 30,
         debug: bool = False,
     ) -> None:
-
+        """
+        :param adafruit_wiznet5k.WIZNET5K eth: Wiznet 5k object
+        :param Sequence[Union[int, bytes]] mac_address: Hardware MAC address.
+        :param Optional[str] hostname: The desired hostname, with optional {} to fill
+            in the MAC address, defaults to None.
+        :param float response_timeout: DHCP Response timeout in seconds, defaults to 30.
+        :param bool debug: Enable debugging output.
+        """
         self._debug = debug
         self._response_timeout = response_timeout
         self._mac_address = mac_address
@@ -157,7 +156,7 @@ class DHCP:
 
         :param int state: DHCP Message state.
         :param float time_elapsed: Number of seconds elapsed since DHCP process started
-        :param bool renew: Set True for renew and rebind
+        :param bool renew: Set True for renew and rebind, defaults to False
         """
         _BUFF[:] = b"\x00" * len(_BUFF)
         # OP
@@ -257,7 +256,8 @@ class DHCP:
         self,
     ) -> Union[Tuple[int, bytes], Tuple[int, int]]:  # TODO: ****
         """Parse DHCP response from DHCP server.
-        Returns DHCP packet type.
+
+        :return Union[Tuple[int, bytes], Tuple[int, int]]: DHCP packet type.
         """
         # store packet in buffer
         _BUFF = self._sock.recv()
@@ -366,7 +366,7 @@ class DHCP:
         return msg_type, xid
 
     # pylint: disable=too-many-branches, too-many-statements
-    def _dhcp_state_machine(self) -> None:  # 2*
+    def _dhcp_state_machine(self) -> None:
         """DHCP state machine without wait loops to enable cooperative multitasking
         This state machine is used both by the initial blocking lease request and
         the non-blocking DHCP maintenance function."""

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -16,7 +16,6 @@ Pure-Python implementation of Jordan Terrell's DHCP library v0.3
 try:
     from typing import Optional, Union, Tuple, Sequence
 
-    from adafruit_wiznet5k import adafruit_wiznet5k
 except ImportError:
     pass
 
@@ -91,7 +90,7 @@ class DHCP:
     # pylint: disable=too-many-arguments, too-many-instance-attributes, invalid-name
     def __init__(
         self,
-        eth: adafruit_wiznet5k.WIZNET5K,
+        eth,
         mac_address: Sequence[Union[int, bytes]],
         hostname: Optional[str] = None,
         response_timeout: float = 30,

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -16,7 +16,6 @@ Pure-Python implementation of Jordan Terrell's DHCP library v0.3
 try:
     from typing import Optional, Union, Tuple, Sequence
 
-    # pylint: disable=cyclic-import
     from adafruit_wiznet5k import adafruit_wiznet5k
 except ImportError:
     pass

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2009 Jordan Terell (blog.jordanterrell.com)
+# SPDX-FileCopyrightText: 2009 Jordan Terrell (blog.jordanterrell.com)
 # SPDX-FileCopyrightText: 2020 Brent Rubell for Adafruit Industries
 # SPDX-FileCopyrightText: 2021 Patrick Van Oosterwijck @ Silicognition LLC
 #

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -14,7 +14,7 @@ Pure-Python implementation of Jordan Terrell's DHCP library v0.3
 
 """
 try:
-    from typing import Optional, Union, List, Tuple
+    from typing import Optional, Union, Tuple, Sequence
 
     # pylint: disable=cyclic-import
     from adafruit_wiznet5k import adafruit_wiznet5k
@@ -101,7 +101,7 @@ class DHCP:
     def __init__(
         self,
         eth: adafruit_wiznet5k.WIZNET5K,
-        mac_address: Union[List[int], Tuple[int]],
+        mac_address: Sequence[Union[int, bytes]],
         hostname: Optional[str] = None,
         response_timeout: float = 30,
         debug: bool = False,
@@ -270,11 +270,13 @@ class DHCP:
             DHCP message OP is not expected BOOT Reply."
 
         xid = _BUFF[4:8]
+        # TODO: ValueError bytes & int
         if bytes(xid) < self._initial_xid:
             print("f")
             return 0, 0
 
         self.local_ip = tuple(_BUFF[16:20])
+        # TODO: Don't think this will ever be True
         if _BUFF[28:34] == 0:
             return 0, 0
 
@@ -362,7 +364,7 @@ class DHCP:
         return msg_type, xid
 
     # pylint: disable=too-many-branches, too-many-statements
-    def _dhcp_state_machine(self) -> None:
+    def _dhcp_state_machine(self) -> None:  # 2*
         """DHCP state machine without wait loops to enable cooperative multitasking
         This state machine is used both by the initial blocking lease request and
         the non-blocking DHCP maintenance function."""

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -369,7 +369,7 @@ class DHCP:
     # pylint: disable=too-many-branches, too-many-statements
     def _dhcp_state_machine(self) -> None:
         """
-        DHCP state machine without wait loops to enable cooperative multitasking
+        DHCP state machine without wait loops to enable cooperative multitasking.
         This state machine is used both by the initial blocking lease request and
         the non-blocking DHCP maintenance function.
         """

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -152,7 +152,8 @@ class DHCP:
         time_elapsed: float,
         renew: bool = False,
     ) -> None:
-        """Assemble and send a DHCP message packet to a socket.
+        """
+        Assemble and send a DHCP message packet to a socket.
 
         :param int state: DHCP Message state.
         :param float time_elapsed: Number of seconds elapsed since DHCP process started
@@ -367,9 +368,11 @@ class DHCP:
 
     # pylint: disable=too-many-branches, too-many-statements
     def _dhcp_state_machine(self) -> None:
-        """DHCP state machine without wait loops to enable cooperative multitasking
+        """
+        DHCP state machine without wait loops to enable cooperative multitasking
         This state machine is used both by the initial blocking lease request and
-        the non-blocking DHCP maintenance function."""
+        the non-blocking DHCP maintenance function.
+        """
         if self._eth.link_status:
             if self._dhcp_state == STATE_DHCP_DISCONN:
                 self._dhcp_state = STATE_DHCP_START

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -13,9 +13,13 @@ Pure-Python implementation of Jordan Terrell's DHCP library v0.3
 * Author(s): Jordan Terrell, Brent Rubell
 
 """
+from __future__ import annotations
+
 try:
     from typing import Optional, Union, Tuple, Sequence
 
+    # pylint: disable=cyclic-import
+    from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 except ImportError:
     pass
 
@@ -90,7 +94,7 @@ class DHCP:
     # pylint: disable=too-many-arguments, too-many-instance-attributes, invalid-name
     def __init__(
         self,
-        eth,
+        eth: WIZNET5K,
         mac_address: Sequence[Union[int, bytes]],
         hostname: Optional[str] = None,
         response_timeout: float = 30,

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -15,8 +15,6 @@ ethernet modules.
 """
 try:
     from typing import Union, Tuple
-
-    from adafruit_wiznet5k import adafruit_wiznet5k
 except ImportError:
     pass
 
@@ -50,7 +48,7 @@ class DNS:
 
     def __init__(
         self,
-        iface: adafruit_wiznet5k.WIZNET5K,
+        iface,
         dns_address: Union[str, Tuple[int, int, int, int]],
         debug: bool = False,
     ) -> None:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -13,6 +13,14 @@ ethernet modules.
 * Author(s): MCQN Ltd, Brent Rubell
 
 """
+try:
+    from typing import Union
+
+    # pylint: disable=cyclic-import
+    from adafruit_wiznet5k import adafruit_wiznet5k
+except ImportError:
+    pass
+
 import time
 from random import getrandbits
 from micropython import const
@@ -44,9 +52,12 @@ class DNS:
     :param iface: Network interface
     """
 
-    # TODO: Add typing
-
-    def __init__(self, iface, dns_address, debug=False):
+    def __init__(
+        self,
+        iface: adafruit_wiznet5k.WIZNET5K,
+        dns_address: str,
+        debug: bool = False,
+    ) -> None:
         self._debug = debug
         self._iface = iface
         socket.set_interface(iface)
@@ -54,13 +65,11 @@ class DNS:
         self._sock.settimeout(1)
 
         self._dns_server = dns_address
-        self._host = 0
+        self._host = 0  # TODO: make b"" to resolve a type error with .decode in _build_dns_ques...
         self._request_id = 0  # request identifier
         self._pkt_buf = bytearray()
 
-    # TODO: Add typing
-
-    def gethostbyname(self, hostname):
+    def gethostbyname(self, hostname: bytes) -> Union[int, bytes]:
         """Translate a host name to IPv4 address format.
 
         :param str hostname: Desired host name to connect to.
@@ -93,14 +102,13 @@ class DNS:
         self._sock.close()
         return addr
 
-    # TODO: Add typing
-
     def _parse_dns_response(
         self,
-    ):  # pylint: disable=too-many-return-statements, too-many-branches, too-many-statements, too-many-locals
-        """Receives and parses DNS query response.
-        Returns desired hostname address if obtained, -1 otherwise.
-
+    ) -> Union[
+        int, bytes
+    ]:  # pylint: disable=too-many-return-statements, too-many-branches, too-many-statements, too-many-locals
+        """Receive and parse DNS query response.
+        Return requested hostname address if obtained, -1 otherwise.
         """
         # wait for a response
         start_time = time.monotonic()
@@ -215,10 +223,8 @@ class DNS:
         # Return address
         return self._pkt_buf[ptr : ptr + 4]
 
-    # TODO: Add typing
-
-    def _build_dns_header(self):
-        """Builds DNS header."""
+    def _build_dns_header(self) -> None:
+        """Build a DNS header."""
         # generate a random, 16-bit, request identifier
         self._request_id = getrandbits(16)
 
@@ -243,10 +249,8 @@ class DNS:
         self._pkt_buf.append(0x00)
         self._pkt_buf.append(0x00)
 
-    # TODO: Add typing
-
-    def _build_dns_question(self):
-        """Build DNS question"""
+    def _build_dns_question(self) -> None:
+        """Build a DNS query."""
         host = self._host.decode("utf-8")
         host = host.split(".")
         # write out each section of host

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -72,7 +72,8 @@ class DNS:
         self._pkt_buf = bytearray()
 
     def gethostbyname(self, hostname: bytes) -> Union[int, bytes]:
-        """DNS look up of a host name.
+        """
+        DNS look up of a host name.
 
         :param bytes hostname: Host name to connect to.
 
@@ -107,11 +108,12 @@ class DNS:
 
     def _parse_dns_response(
         self,
-    ) -> Union[
-        int, bytes
-    ]:  # pylint: disable=too-many-return-statements, too-many-branches, too-many-statements, too-many-locals
-        """Receive and parse DNS query response.
-        Return requested hostname address if obtained, -1 otherwise.
+    ) -> Union[int, bytes]:
+        # pylint: disable=too-many-return-statements, too-many-branches, too-many-statements, too-many-locals
+        """
+        Receive and parse DNS query response.
+
+        :return Union[int, bytes]: Requested hostname IP address if obtained, -1 otherwise.
         """
         # wait for a response
         start_time = time.monotonic()

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -47,10 +47,7 @@ DNS_PORT = const(0x35)  # port used for DNS request
 
 
 class DNS:
-    """W5K DNS implementation.
-
-    :param iface: Network interface
-    """
+    """W5K DNS implementation."""
 
     def __init__(
         self,
@@ -58,6 +55,11 @@ class DNS:
         dns_address: Union[str, Tuple[int, int, int, int]],
         debug: bool = False,
     ) -> None:
+        """
+        :param adafruit_wiznet5k.WIZNET5K: Ethernet network connection.
+        :param Union[str, Tuple[int, int, int, int]]: IP address of the DNS server.
+        :param bool debug: Enable debugging messages, defaults to False.
+        """
         self._debug = debug
         self._iface = iface
         socket.set_interface(iface)
@@ -70,12 +72,13 @@ class DNS:
         self._pkt_buf = bytearray()
 
     def gethostbyname(self, hostname: bytes) -> Union[int, bytes]:
-        """Translate a host name to IPv4 address format.
+        """DNS look up of a host name.
 
-        :param str hostname: Desired host name to connect to.
+        :param bytes hostname: Host name to connect to.
 
-        Returns the IPv4 address as a bytearray if successful, -1 otherwise.
+        :return Union[int, bytes] The IPv4 address if successful, -1 otherwise.
         """
+        # TODO: See if it will take a string.
         if self._dns_server is None:
             return INVALID_SERVER
         self._host = hostname

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -66,7 +66,7 @@ class DNS:
         self._sock.settimeout(1)
 
         self._dns_server = dns_address
-        self._host = 0  # TODO: make b"" to resolve a type error with .decode in _build_dns_ques...
+        self._host = 0
         self._request_id = 0  # request identifier
         self._pkt_buf = bytearray()
 
@@ -78,7 +78,6 @@ class DNS:
 
         :return Union[int, bytes] The IPv4 address if successful, -1 otherwise.
         """
-        # TODO: See if it will take a string.
         if self._dns_server is None:
             return INVALID_SERVER
         self._host = hostname
@@ -143,7 +142,7 @@ class DNS:
             return -1
         # Validate flags
         flags = int.from_bytes(self._pkt_buf[2:4], "big")
-        if not flags in (0x8180, 0x8580):  # TODO: Should be `flags not in ...`
+        if not flags in (0x8180, 0x8580):
             if self._debug:
                 print("* DNS ERROR: Invalid flags, ", flags)
             return -1

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -14,7 +14,7 @@ ethernet modules.
 
 """
 try:
-    from typing import Union
+    from typing import Union, Tuple
 
     # pylint: disable=cyclic-import
     from adafruit_wiznet5k import adafruit_wiznet5k
@@ -55,7 +55,7 @@ class DNS:
     def __init__(
         self,
         iface: adafruit_wiznet5k.WIZNET5K,
-        dns_address: str,
+        dns_address: Union[str, Tuple[int, int, int, int]],
         debug: bool = False,
     ) -> None:
         self._debug = debug
@@ -139,7 +139,7 @@ class DNS:
             return -1
         # Validate flags
         flags = int.from_bytes(self._pkt_buf[2:4], "big")
-        if not flags in (0x8180, 0x8580):
+        if not flags in (0x8180, 0x8580):  # TODO: Should be `flags not in ...`
             if self._debug:
                 print("* DNS ERROR: Invalid flags, ", flags)
             return -1

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -16,7 +16,6 @@ ethernet modules.
 try:
     from typing import Union, Tuple
 
-    # pylint: disable=cyclic-import
     from adafruit_wiznet5k import adafruit_wiznet5k
 except ImportError:
     pass

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -44,6 +44,8 @@ class DNS:
     :param iface: Network interface
     """
 
+    # TODO: Add typing
+
     def __init__(self, iface, dns_address, debug=False):
         self._debug = debug
         self._iface = iface
@@ -55,6 +57,8 @@ class DNS:
         self._host = 0
         self._request_id = 0  # request identifier
         self._pkt_buf = bytearray()
+
+    # TODO: Add typing
 
     def gethostbyname(self, hostname):
         """Translate a host name to IPv4 address format.
@@ -88,6 +92,8 @@ class DNS:
 
         self._sock.close()
         return addr
+
+    # TODO: Add typing
 
     def _parse_dns_response(
         self,
@@ -209,6 +215,8 @@ class DNS:
         # Return address
         return self._pkt_buf[ptr : ptr + 4]
 
+    # TODO: Add typing
+
     def _build_dns_header(self):
         """Builds DNS header."""
         # generate a random, 16-bit, request identifier
@@ -234,6 +242,8 @@ class DNS:
         # ARCOUNT
         self._pkt_buf.append(0x00)
         self._pkt_buf.append(0x00)
+
+    # TODO: Add typing
 
     def _build_dns_question(self):
         """Build DNS question"""

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -13,8 +13,13 @@ ethernet modules.
 * Author(s): MCQN Ltd, Brent Rubell
 
 """
+from __future__ import annotations
+
 try:
     from typing import Union, Tuple
+
+    # pylint: disable=cyclic-import
+    from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 except ImportError:
     pass
 
@@ -23,7 +28,6 @@ from random import getrandbits
 from micropython import const
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 from adafruit_wiznet5k.adafruit_wiznet5k_socket import htons
-
 
 QUERY_FLAG = const(0x00)
 OPCODE_STANDARD_QUERY = const(0x00)
@@ -48,7 +52,7 @@ class DNS:
 
     def __init__(
         self,
-        iface,
+        iface: WIZNET5K,
         dns_address: Union[str, Tuple[int, int, int, int]],
         debug: bool = False,
     ) -> None:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -68,7 +68,7 @@ class DNS:
         self._sock.settimeout(1)
 
         self._dns_server = dns_address
-        self._host = 0
+        self._host = b""
         self._request_id = 0  # request identifier
         self._pkt_buf = bytearray()
 
@@ -136,7 +136,7 @@ class DNS:
         if not xid == self._request_id:
             if self._debug:
                 print(
-                    "* DNS ERROR: Received request identifer {} \
+                    "* DNS ERROR: Received request identifier {} \
                       does not match expected {}".format(
                         xid, self._request_id
                     )

--- a/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
@@ -17,8 +17,11 @@ Implementation Notes
 
 
 """
+from __future__ import annotations
+
 try:
     import typing  # pylint: disable=unused-import
+    from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 except ImportError:
     pass
 import time
@@ -33,7 +36,7 @@ class NTP:
 
     def __init__(
         self,
-        iface,
+        iface: WIZNET5K,
         ntp_address: str,
         utc: int,
         debug: bool = False,

--- a/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
@@ -33,13 +33,7 @@ import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 
 class NTP:
     """
-    Wiznet5k NTP Client
-
-    :param iface: Wiznet 5k object
-    :param str ntp_address: The hostname of the NTP server
-    :param int utc: Numbers of hours to offset time from UTC
-    :param bool debug: Enable debugging output.
-    """
+    Wiznet5k NTP Client."""
 
     def __init__(
         self,
@@ -48,6 +42,12 @@ class NTP:
         utc: int,  # TODO: Should be float. India is UTC + 7.5
         debug: bool = False,
     ) -> None:
+        """
+        :param adafruit_wiznet5k.WIZNET5K iface: Wiznet 5k object.
+        :param str ntp_address: The hostname of the NTP server.
+        :param int utc: Numbers of hours to offset time from UTC.
+        :param bool debug: Enable debugging output, defaults to False.
+        """
         self._debug = debug
         self._iface = iface
         socket.set_interface(self._iface)
@@ -63,9 +63,9 @@ class NTP:
 
     def get_time(self) -> time.struct_time:
         """
-        Get the time from the NTP server
+        Get the time from the NTP server.
 
-        :return: time in seconds since the epoch
+        :return int: Time in seconds since the epoch.
         """
         self._sock.bind((None, 50001))
         self._sock.sendto(self._pkt_buf_, (self._ntp_server, 123))

--- a/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
@@ -38,7 +38,7 @@ class NTP:
         self,
         iface: WIZNET5K,
         ntp_address: str,
-        utc: int,
+        utc: float,
         debug: bool = False,
     ) -> None:
         """
@@ -64,7 +64,7 @@ class NTP:
         """
         Get the time from the NTP server.
 
-        :return int: Time in seconds since the epoch.
+        :return time.struct_time: The local time.
         """
         self._sock.bind((None, 50001))
         self._sock.sendto(self._pkt_buf_, (self._ntp_server, 123))
@@ -73,6 +73,7 @@ class NTP:
             if data:
                 sec = data[40:44]
                 int_cal = int.from_bytes(sec, "big")
-                cal = int_cal - 2208988800 + self._utc * 3600
+                # UTC offset may be a float as some offsets are half hours so force int.
+                cal = int(int_cal - 2208988800 + self._utc * 3600)
                 cal = time.localtime(cal)
                 return cal

--- a/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
@@ -37,7 +37,7 @@ class NTP:
         self,
         iface: adafruit_wiznet5k.WIZNET5K,
         ntp_address: str,
-        utc: int,  # TODO: Should be float. India is UTC + 7.5
+        utc: int,
         debug: bool = False,
     ) -> None:
         """

--- a/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
@@ -20,7 +20,6 @@ Implementation Notes
 try:
     import typing  # pylint: disable=unused-import
 
-    # pylint: disable=cyclic-import
     from adafruit_wiznet5k import adafruit_wiznet5k
 except ImportError:
     pass

--- a/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
@@ -32,8 +32,7 @@ import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 
 
 class NTP:
-    """
-    Wiznet5k NTP Client."""
+    """Wiznet5k NTP Client."""
 
     def __init__(
         self,

--- a/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
@@ -17,6 +17,13 @@ Implementation Notes
 
 
 """
+try:
+    import typing  # pylint: disable=unused-import
+
+    # pylint: disable=cyclic-import
+    from adafruit_wiznet5k import adafruit_wiznet5k
+except ImportError:
+    pass
 import time
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 
@@ -34,7 +41,13 @@ class NTP:
     :param bool debug: Enable debugging output.
     """
 
-    def __init__(self, iface, ntp_address, utc, debug=False):
+    def __init__(
+        self,
+        iface: adafruit_wiznet5k.WIZNET5K,
+        ntp_address: str,
+        utc: int,  # TODO: Should be float. India is UTC + 7.5
+        debug: bool = False,
+    ) -> None:
         self._debug = debug
         self._iface = iface
         socket.set_interface(self._iface)
@@ -48,7 +61,7 @@ class NTP:
 
         self._pkt_buf_ = bytearray([0x23] + [0x00] * 55)
 
-    def get_time(self):
+    def get_time(self) -> time.struct_time:
         """
         Get the time from the NTP server
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
@@ -19,8 +19,6 @@ Implementation Notes
 """
 try:
     import typing  # pylint: disable=unused-import
-
-    from adafruit_wiznet5k import adafruit_wiznet5k
 except ImportError:
     pass
 import time
@@ -35,7 +33,7 @@ class NTP:
 
     def __init__(
         self,
-        iface: adafruit_wiznet5k.WIZNET5K,
+        iface,
         ntp_address: str,
         utc: int,
         debug: bool = False,

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -283,7 +283,7 @@ class socket:
             raise RuntimeError("Failed to connect to host", host)
         self._buffer = b""
 
-    def send(self, data: bytearray) -> None:
+    def send(self, data: Union[bytes, bytearray]) -> None:
         """Send data to the socket. The socket must be connected to
         a remote socket.
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -539,8 +539,8 @@ class socket:
         """
         Read a line from the socket.
 
-        Attempt to return as many bytes as we can up to but not including carriage return and
-        linefeed charater pairs.
+        Attempt to return as many bytes as we can up to but not including a carriage return and
+        linefeed charater pair.
 
         :return bytes: The data read from the socket.
         """

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -476,7 +476,8 @@ class socket:
     def recvfrom(
         self, bufsize: int = 0, flags: Any = 0
     ) -> Tuple[bytes, Tuple[str, int]]:
-        """Reads some bytes from the connected remote address.
+        """
+        Read some bytes from the connected remote address.
 
         :param int bufsize: Maximum number of bytes to receive.
         :param Any flags: ignored, present for compatibility.

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -12,8 +12,13 @@ A socket compatible interface with the Wiznet5k module.
 * Author(s): ladyada, Brent Rubell, Patrick Van Oosterwijck, Adam Cummick
 
 """
+from __future__ import annotations
+
 try:
     from typing import Any, Optional, Tuple, List, Union
+
+    # pylint: disable=cyclic-import
+    from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 except ImportError:
     pass
 
@@ -24,10 +29,10 @@ from micropython import const
 import adafruit_wiznet5k as wiznet5k
 
 # pylint: disable=invalid-name
-_the_interface: Union[wiznet5k.adafruit_wiznet5k.WIZNET5K, None] = None
+_the_interface: Optional[WIZNET5K] = None
 
 
-def set_interface(iface: wiznet5k.adafruit_wiznet5k.WIZNET5K) -> None:
+def set_interface(iface: WIZNET5K) -> None:
     """
     Helper to set the global internet interface.
 
@@ -282,12 +287,8 @@ class socket:
 
     def accept(
         self,
-    ) -> Optional[
-        Tuple[
-            wiznet5k.adafruit_wiznet5k_socket.socket,
-            Tuple[Union[str, bytearray], Union[int, bytearray]],
-        ]
-    ]:
+    ) -> Optional[Tuple[socket, Tuple[Union[str, bytearray], Union[int, bytearray]],]]:
+        # wiznet5k.adafruit_wiznet5k_socket.socket,
         """
         Accept a connection.
 
@@ -297,7 +298,7 @@ class socket:
         socket object to send and receive data on the connection, and address is
         the address bound to the socket on the other end of the connection.
 
-        :return Union[int, Tuple[int, Tuple[Union[str, bytearray], Union[int, bytearray]]], None]:
+        :return Optional[Tuple[socket.socket, Tuple[Union[str, bytearray], Union[int, bytearray]]]:
             If successful (socket object, (IP address, port)). If errors occur, the IP address
             and / or the port may be returned as bytearrays.
         """
@@ -583,7 +584,7 @@ class socket:
             raise Exception("Timeout period should be non-negative.")
         self._timeout = value
 
-    def gettimeout(self) -> Union[float, None]:
+    def gettimeout(self) -> Optional[float]:
         """
         Timeout associated with socket operations.
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -79,21 +79,23 @@ def getaddrinfo(
     family: int = 0,
     socktype: int = 0,
     proto: int = 0,
-    flags: Any = 0,
+    flags: int = 0,
 ) -> List[Tuple[int, int, int, str, Tuple[str, int]]]:
     """
     Translate the host/port argument into a sequence of 5-tuples that
     contain all the necessary arguments for creating a socket connected to that service.
 
-    :param str host: Host to connect to.
+    :param str host: a domain name, a string representation of an IPv4/v6 address or
+        None.
     :param int port: Port number to connect to (0 - 65536).
     :param int family: Ignored and hardcoded as 0x03 (the only family implemented) by the function.
     :param int socktype: The type of socket, either SOCK_STREAM (0x21) for TCP or SOCK_DGRAM (0x02)
         for UDP, defaults to 0x00.
-    :param int proto: Protocol, unused in this implementation of socket.
-    :param Any flags: Socket flags, unused in this implementation,.
+    :param int proto: Unused in this implementation of socket.
+    :param int flags: Unused in this implementation of socket.
     """
-
+    # TODO: Python socket accepts port as a string or int or None. How are str and None handled?
+    # TODO: Python socket has arg type in place of socktype.
     if not isinstance(port, int):
         raise RuntimeError("Port must be an integer")
     if is_ipv4(host):
@@ -107,7 +109,7 @@ def gethostbyname(hostname: str) -> str:
 
     :param str hostname: Hostname to lookup.
 
-    :return str: IPv4 address in 0.0.0.0 form.
+    :return str: IPv4 address (a string of the form '255.255.255.255').
     """
     addr = _the_interface.get_host_by_name(hostname)
     addr = "{}.{}.{}.{}".format(addr[0], addr[1], addr[2], addr[3])
@@ -116,7 +118,7 @@ def gethostbyname(hostname: str) -> str:
 
 def is_ipv4(host: str) -> bool:
     """
-    Check if a hostname is an IPv4 address in the form 0.0.0.0.
+    Check if a hostname is an IPv4 address (a string of the form '255.255.255.255').
 
     :param str host: Hostname to check.
 
@@ -133,8 +135,10 @@ def is_ipv4(host: str) -> bool:
 
 # pylint: disable=invalid-name, too-many-public-methods
 class socket:
-    """A simplified implementation of the Python 'socket' class for connecting
-    to a Wiznet5k module."""
+    """
+    A simplified implementation of the Python 'socket' class for connecting
+    to a Wiznet5k module.
+    """
 
     # pylint: disable=redefined-builtin,unused-argument
     def __init__(
@@ -225,10 +229,11 @@ class socket:
         return result
 
     def getpeername(self) -> Union[str, bytearray]:
-        """Return the remote address to which the socket is connected.
+        """
+        Return the remote address to which the socket is connected.
 
-        :return Union[str, bytearray]: An IPv4 address in the form 0.0.0.0. An error may return
-            a bytearray.
+        :return Union[str, bytearray]: An IPv4 address (a string of the form '255.255.255.255').
+            An error may return a bytearray.
         """
         return _the_interface.remote_ip(self.socknum)
 
@@ -236,7 +241,7 @@ class socket:
         """
         Convert an IPv4 address from dotted-quad string format.
 
-        :param str ip_string: IPv4 address in the form 0.0.0.0.
+        :param str ip_string: IPv4 address (a string of the form '255.255.255.255').
 
         :return bytearray: IPv4 address as a 4 byte bytearray.
         """
@@ -251,8 +256,8 @@ class socket:
         If the host is specified the interface will be reconfigured to that IP address.
 
         :param Tuple[Optional[str], int] address: Address as a (host, port) tuple. The host
-            may be an IPv4 address in 0.0.0.0 form, or None. The port number is in the range
-            90- 65536).
+            may be an IPv4 address (a string of the form '255.255.255.255'), or None.
+            The port number is in the range (0- 65536).
         """
         if address[0] is not None:
             ip_address = _the_interface.unpretty_ip(address[0])
@@ -383,7 +388,8 @@ class socket:
         bufsize: int = 0,
         flags: Any = 0,
     ) -> bytes:
-        """Reads from the connected remote address.
+        """
+        Read from the connected remote address.
 
         :param int bufsize: Maximum number of bytes to receive.
         :param int flags: ignored, present for compatibility.
@@ -449,7 +455,7 @@ class socket:
         self, bufsize: int = 0, flags: Any = 0
     ) -> bytes:  # pylint: disable=too-many-branches
         """
-        Reads from the connected remote address.
+        Read from the connected remote address.
 
         :param int bufsize: Maximum number of bytes to receive, ignored by the
             function, defaults to 0.
@@ -494,7 +500,8 @@ class socket:
         )
 
     def recv_into(self, buf: bytearray, nbytes: int = 0, flags: Any = 0) -> int:
-        """Read from the connected remote address into the provided buffer.
+        """
+        Read from the connected remote address into the provided buffer.
 
         :param bytearray buf: Data buffer
         :param nbytes: Maximum number of bytes to receive
@@ -512,13 +519,14 @@ class socket:
     def recvfrom_into(
         self, buf: bytearray, nbytes: int = 0, flags: Any = 0
     ) -> Tuple[int, Tuple[str, int]]:
-        """Reads some bytes from the connected remote address into the provided buffer.
+        """
+        Read some bytes from the connected remote address into the provided buffer.
 
         :param bytearray buf: Data buffer.
         :param int nbytes: Maximum number of bytes to receive.
-        :param int flags: ignored, present for compatibility.
+        :param int flags: Unused, present for compatibility.
 
-        :return: a tuple (nbytes, address) where address is a tuple (ip, port)
+        :return: A tuple (nbytes, address) where address is a tuple (ip, port)
         """
         return (
             self.recv_into(buf, nbytes),

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -148,8 +148,8 @@ class socket:
         family: int = AF_INET,
         type: int = SOCK_STREAM,
         proto: Any = 0,
-        fileno: Optional[Any] = None,
-        socknum: Optional[Any] = None,
+        fileno: Optional[int] = None,
+        socknum: Optional[int] = None,
     ) -> None:
         """
         :param int family: Socket address (and protocol) family, defaults to AF_INET.
@@ -315,7 +315,7 @@ class socket:
 
         new_listen_socknum, addr = _the_interface.socket_accept(self.socknum)
         current_socknum = self.socknum
-        # Create a new socket object and swap socket nums so we can continue listening
+        # Create a new socket object and swap socket nums, so we can continue listening
         client_sock = socket()
         client_sock._socknum = current_socknum  # pylint: disable=protected-access
         self._socknum = new_listen_socknum  # pylint: disable=protected-access

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -193,7 +193,7 @@ class socket:
         self._buffer = bytearray(self._buffer)
         return self._buffer
 
-    def bind(self, address: str) -> None:
+    def bind(self, address: Tuple[Optional[str], int]) -> None:
         """Bind the socket to the listen port, if host is specified the interface
         will be reconfigured to that IP.
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -93,8 +93,6 @@ def getaddrinfo(
     :param int proto: Unused in this implementation of socket.
     :param int flags: Unused in this implementation of socket.
     """
-    # TODO: Python socket accepts port as a string or int or None. How are str and None handled?
-    # TODO: Python socket has arg type in place of socktype.
     if not isinstance(port, int):
         raise RuntimeError("Port must be an integer")
     if is_ipv4(host):
@@ -322,7 +320,6 @@ class socket:
         self._socknum = new_listen_socknum  # pylint: disable=protected-access
         self.bind((None, self._listen_port))
         self.listen()
-        # TODO: Weird logic below. Should be an if, not a while
         while self.status != wiznet5k.adafruit_wiznet5k.SNSR_SOCK_LISTEN:
             raise RuntimeError("Failed to open new listening socket")
         return client_sock, addr
@@ -340,7 +337,6 @@ class socket:
         :param Optional[int] conntype: Raises an exception if set to 3, unused otherwise, defaults
             to None.
         """
-        # TODO: conntype unused beyond raising an exception.
         assert (
             conntype != 0x03
         ), "Error: SSL/TLS is not currently supported by CircuitPython."
@@ -380,7 +376,7 @@ class socket:
         :param tuple address: Remote socket as a (host, port) tuple.
         """
         self.connect(address)
-        return self.send(data)  # TODO: send only returns None, so can delete
+        return self.send(data)
 
     def recv(
         # pylint: disable=too-many-branches
@@ -431,9 +427,7 @@ class socket:
                 elif self._sock_type == SOCK_DGRAM:
                     recv = _the_interface.read_udp(self.socknum, min(to_read, avail))[1]
                     to_read = len(recv)  # only get this dgram
-                recv = bytes(
-                    recv
-                )  # TODO: Maybe raise a specific exception before this line
+                recv = bytes(recv)
                 received.append(recv)
                 to_read -= len(recv)
                 gc.collect()
@@ -441,7 +435,7 @@ class socket:
                 break
         self._buffer += b"".join(received)
 
-        ret = None  # TODO: Unused definition
+        ret = None
         if len(self._buffer) == bufsize:
             ret = self._buffer
             self._buffer = b""
@@ -463,9 +457,8 @@ class socket:
 
         :return bytes: All data available from the connection.
         """
-        # TODO: bufsize unused
         # print("Socket read", bufsize)
-        ret = None  # TODO: Useless definition
+        ret = None
         avail = self.available()
         if avail:
             if self._sock_type == SOCK_STREAM:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -21,7 +21,6 @@ import gc
 import time
 from micropython import const
 
-# pylint is tripping over importing for typing so disable
 import adafruit_wiznet5k as wiznet5k
 
 # pylint: disable=invalid-name

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -86,8 +86,8 @@ def getaddrinfo(
     flags: int = 0,
 ) -> List[Tuple[int, int, int, str, Tuple[str, int]]]:
     """
-    Translate the host/port argument into a sequence of 5-tuples that
-    contain all the necessary arguments for creating a socket connected to that service.
+    Translate the host/port argument into a sequence of 5-tuples that contain all the necessary
+    arguments for creating a socket connected to that service.
 
     :param str host: a domain name, a string representation of an IPv4/v6 address or
         None.
@@ -97,6 +97,8 @@ def getaddrinfo(
         for UDP, defaults to 0x00.
     :param int proto: Unused in this implementation of socket.
     :param int flags: Unused in this implementation of socket.
+
+    :return List[Tuple[int, int, int, str, Tuple[str, int]]]: Address info entries.
     """
     if not isinstance(port, int):
         raise RuntimeError("Port must be an integer")
@@ -191,7 +193,7 @@ class socket:
         """
         Return the socket object's socket number.
 
-        :return int: The socket number
+        :return int: Socket number.
         """
         return self._socknum
 
@@ -259,7 +261,7 @@ class socket:
 
         :param Tuple[Optional[str], int] address: Address as a (host, port) tuple. The host
             may be an IPv4 address (a string of the form '255.255.255.255'), or None.
-            The port number is in the range (0- 65536).
+            The port number is in the range (0 - 65536).
         """
         if address[0] is not None:
             ip_address = _the_interface.unpretty_ip(address[0])
@@ -279,7 +281,7 @@ class socket:
         """
         Listen on the port specified by bind.
 
-        :param backlog: For compatibility but ignored.
+        :param Optional[Any] backlog: Included for compatibility but ignored.
         """
         assert self._listen_port is not None, "Use bind to set the port before listen!"
         _the_interface.socket_listen(self.socknum, self._listen_port)
@@ -373,7 +375,7 @@ class socket:
         """
         Connect to a remote socket and send data.
 
-        :param bytearray data: Desired data to send to the socket.
+        :param bytearray data: Data to send to the socket.
         :param tuple address: Remote socket as a (host, port) tuple.
         """
         self.connect(address)
@@ -390,6 +392,8 @@ class socket:
 
         :param int bufsize: Maximum number of bytes to receive.
         :param int flags: ignored, present for compatibility.
+
+        :return bytes: Data from the remote address.
         """
         if self.status == wiznet5k.adafruit_wiznet5k.SNSR_SOCK_CLOSED:
             return b""
@@ -501,7 +505,7 @@ class socket:
         :param nbytes: Maximum number of bytes to receive
         :param Any flags: ignored, present for compatibility.
 
-        :return: the number of bytes received
+        :return int: the number of bytes received
         """
         if nbytes == 0:
             nbytes = len(buf)
@@ -520,7 +524,8 @@ class socket:
         :param int nbytes: Maximum number of bytes to receive.
         :param int flags: Unused, present for compatibility.
 
-        :return: A tuple (nbytes, address) where address is a tuple (ip, port)
+        :return Tuple[int, Tuple[str, int]]: A tuple (nbytes, address) where address is a
+            tuple (ip, port)
         """
         return (
             self.recv_into(buf, nbytes),
@@ -534,7 +539,8 @@ class socket:
         """
         Read a line from the socket.
 
-        Attempt to return as many bytes as we can up to but not including '\r\n'.
+        Attempt to return as many bytes as we can up to but not including carriage return and
+        linefeed charater pairs.
 
         :return bytes: The data read from the socket.
         """

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -12,6 +12,11 @@ A socket compatible interface with the Wiznet5k module.
 * Author(s): ladyada, Brent Rubell, Patrick Van Oosterwijck, Adam Cummick
 
 """
+try:
+    import typing  # pylint: disable=unused-import
+except ImportError:
+    pass
+
 import gc
 import time
 from micropython import const
@@ -26,7 +31,7 @@ def set_interface(iface):
     _the_interface = iface
 
 
-def htonl(x):
+def htonl(x: int) -> int:
     """Convert 32-bit positive integers from host to network byte order."""
     return (
         ((x) << 24 & 0xFF000000)
@@ -36,7 +41,7 @@ def htonl(x):
     )
 
 
-def htons(x):
+def htons(x: int) -> int:
     """Convert 16-bit positive integers from host to network byte order."""
     return (((x) << 8) & 0xFF00) | (((x) >> 8) & 0xFF)
 
@@ -49,7 +54,7 @@ SOCKET_INVALID = const(255)
 
 
 # pylint: disable=too-many-arguments, unused-argument
-def getaddrinfo(host, port, family=0, socktype=0, proto=0, flags=0):
+def getaddrinfo(host, port: int, family=0, socktype: int = 0, proto=0, flags=0):
     """Translate the host/port argument into a sequence of 5-tuples that
     contain all the necessary arguments for creating a socket connected to that service.
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -285,10 +285,11 @@ class socket:
 
     def accept(
         self,
-    ) -> Union[
-        wiznet5k.adafruit_wiznet5k_socket.socket,
-        Tuple[int, Tuple[Union[str, bytearray], Union[int, bytearray]]],
-        None,
+    ) -> Optional[
+        Tuple[
+            wiznet5k.adafruit_wiznet5k_socket.socket,
+            Tuple[Union[str, bytearray], Union[int, bytearray]],
+        ]
     ]:
         """
         Accept a connection.

--- a/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
@@ -41,7 +41,7 @@ import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 _the_interface = None  # pylint: disable=invalid-name
 
 
-def set_interface(iface: wiznet5k.adafruit_wiznet5k.WIZNET5K) -> None:
+def set_interface(iface) -> None:
     """
     Helper to set the global internet interface.
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
@@ -181,7 +181,7 @@ class WSGIServer:
         The application callable will be given the resulting environ dictionary.
         It contains metadata about the incoming request and the request body ("wsgi.input")
 
-        :param socket.socket client: socket to read the request from
+        :param socket.socket client: socket to read the request from.
 
         :return Dict: Data for the application callable.
         """

--- a/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
@@ -180,7 +180,7 @@ class WSGIServer:
         The application callable will be given the resulting environ dictionary.
         It contains metadata about the incoming request and the request body ("wsgi.input")
 
-        :param socket.socket client: socket to read the request from.
+        :param socket.socket client: Socket to read the request from.
 
         :return Dict: Data for the application callable.
         """

--- a/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
@@ -27,6 +27,10 @@ https://www.python.org/dev/peps/pep-0333/
 * Author(s): Matt Costi, Patrick Van Oosterwijck
 """
 # pylint: disable=no-name-in-module
+try:
+    from typing import Optional, List, Tuple, Dict
+except ImportError:
+    pass
 
 import io
 import gc
@@ -40,7 +44,7 @@ _the_interface = None  # pylint: disable=invalid-name
 # TODO: Add typing
 
 
-def set_interface(iface):
+def set_interface(iface: wiznet5k.adafruit_wiznet5k.WIZNET5K) -> None:
     """Helper to set the global internet interface"""
     global _the_interface  # pylint: disable=global-statement, invalid-name
     _the_interface = iface
@@ -53,9 +57,12 @@ class WSGIServer:
     A simple server that implements the WSGI interface
     """
 
-    # TODO: Add typing
-
-    def __init__(self, port=80, debug=False, application=None):
+    def __init__(
+        self,
+        port: int = 80,
+        debug: bool = False,
+        application: Optional[callable] = None,
+    ) -> None:
         self.application = application
         self.port = port
         self._timeout = 20
@@ -71,9 +78,7 @@ class WSGIServer:
         if self._debug:
             print("Max sockets: ", self.MAX_SOCK_NUM)
 
-    # TODO: Add typing
-
-    def start(self):
+    def start(self) -> None:
         """
         Starts the server and begins listening for incoming connections.
         Call update_poll in the main loop for the application callable to be
@@ -89,9 +94,7 @@ class WSGIServer:
             ip = _the_interface.pretty_ip(_the_interface.ip_address)
             print("Server available at {0}:{1}".format(ip, self.port))
 
-    # TODO: Add typing
-
-    def update_poll(self):
+    def update_poll(self) -> None:
         """
         Call this method inside your main event loop to get the server
         check for new incoming client requests. When a request comes in,
@@ -117,9 +120,7 @@ class WSGIServer:
             except RuntimeError:
                 pass
 
-    # TODO: Add typing
-
-    def finish_response(self, result, client):
+    def finish_response(self, result: str, client: socket.socket) -> None:
         """
         Called after the application callable returns result data to respond with.
         Creates the HTTP Response payload from the response_headers and results data,
@@ -151,9 +152,9 @@ class WSGIServer:
             client.disconnect()
             client.close()
 
-    # TODO: Add typing
-
-    def _start_response(self, status, response_headers):
+    def _start_response(
+        self, status: str, response_headers: List[Tuple[str, str]]
+    ) -> None:
         """
         The application callable will be given this method as the second param
         This is to be called before the application callable returns, to signify
@@ -166,9 +167,7 @@ class WSGIServer:
         self._response_status = status
         self._response_headers = [("Server", "w5kWSGIServer")] + response_headers
 
-    # TODO: Add typing
-
-    def _get_environ(self, client):
+    def _get_environ(self, client: socket.socket) -> Dict:
         """
         The application callable will be given the resulting environ dictionary.
         It contains metadata about the incoming request and the request body ("wsgi.input")
@@ -209,10 +208,10 @@ class WSGIServer:
         if "content-length" in headers:
             env["CONTENT_LENGTH"] = headers.get("content-length")
             body = client.recv(int(env["CONTENT_LENGTH"]))
-            env["wsgi.input"] = io.StringIO(body)
+            env["wsgi.input"] = io.StringIO(body)  # TODO: Is bytes should be str
         else:
             body = client.recv()
-            env["wsgi.input"] = io.StringIO(body)
+            env["wsgi.input"] = io.StringIO(body)  # TODO: Is bytes should be str
         for name, value in headers.items():
             key = "HTTP_" + name.replace("-", "_").upper()
             if key in env:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
@@ -41,11 +41,12 @@ import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 _the_interface = None  # pylint: disable=invalid-name
 
 
-# TODO: Add typing
-
-
 def set_interface(iface: wiznet5k.adafruit_wiznet5k.WIZNET5K) -> None:
-    """Helper to set the global internet interface"""
+    """
+    Helper to set the global internet interface.
+
+    :param wiznet5k.adafruit_wiznet5k.WIZNET5K: Ethernet interface.
+    """
     global _the_interface  # pylint: disable=global-statement, invalid-name
     _the_interface = iface
     socket.set_interface(iface)
@@ -53,9 +54,7 @@ def set_interface(iface: wiznet5k.adafruit_wiznet5k.WIZNET5K) -> None:
 
 # pylint: disable=invalid-name
 class WSGIServer:
-    """
-    A simple server that implements the WSGI interface
-    """
+    """A simple server that implements the WSGI interface."""
 
     def __init__(
         self,
@@ -63,6 +62,11 @@ class WSGIServer:
         debug: bool = False,
         application: Optional[callable] = None,
     ) -> None:
+        """
+        :param int port: WSGI server port, defaults to 80.
+        :param bool debug: Enable debugging, defaults to False.
+        :param Optional[callable] application: Application to call in response to a HTTP request.
+        """
         self.application = application
         self.port = port
         self._timeout = 20
@@ -80,7 +84,8 @@ class WSGIServer:
 
     def start(self) -> None:
         """
-        Starts the server and begins listening for incoming connections.
+        Start the server and listen for incoming connections.
+
         Call update_poll in the main loop for the application callable to be
         invoked on receiving an incoming request.
         """
@@ -96,6 +101,8 @@ class WSGIServer:
 
     def update_poll(self) -> None:
         """
+        Check for new incoming client requests.
+
         Call this method inside your main event loop to get the server
         check for new incoming client requests. When a request comes in,
         the application callable will be invoked.
@@ -126,8 +133,8 @@ class WSGIServer:
         Creates the HTTP Response payload from the response_headers and results data,
         and sends it back to client.
 
-        :param string result: the data string to send back in the response to the client.
-        :param Socket client: the socket to send the response to.
+        :param str result: the data string to send back in the response to the client.
+        :param socket.socket client: the socket to send the response to.
         """
         try:
             response = "HTTP/1.1 {0}\r\n".format(self._response_status)
@@ -160,8 +167,8 @@ class WSGIServer:
         This is to be called before the application callable returns, to signify
         the response can be started with the given status and headers.
 
-        :param string status: a status string including the code and reason. ex: "200 OK"
-        :param list response_headers: a list of tuples to represent the headers.
+        :param str status: a status string including the code and reason. ex: "200 OK"
+        :param List[Tuple[str, str]] response_headers: a list of tuples to represent the headers.
             ex ("header-name", "header value")
         """
         self._response_status = status
@@ -172,7 +179,9 @@ class WSGIServer:
         The application callable will be given the resulting environ dictionary.
         It contains metadata about the incoming request and the request body ("wsgi.input")
 
-        :param Socket client: socket to read the request from
+        :param socket.socket client: socket to read the request from
+
+        :return Dict: Data for the application callable.
         """
         env = {}
         line = str(client.readline(), "utf-8")

--- a/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
@@ -27,8 +27,10 @@ https://www.python.org/dev/peps/pep-0333/
 * Author(s): Matt Costi, Patrick Van Oosterwijck
 """
 # pylint: disable=no-name-in-module
+# from __future__ import annotations
 try:
     from typing import Optional, List, Tuple, Dict
+    from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 except ImportError:
     pass
 
@@ -38,10 +40,10 @@ from micropython import const
 import adafruit_wiznet5k as wiznet5k
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 
-_the_interface = None  # pylint: disable=invalid-name
+_the_interface: Optional[WIZNET5K] = None  # pylint: disable=invalid-name
 
 
-def set_interface(iface) -> None:
+def set_interface(iface: WIZNET5K) -> None:
     """
     Helper to set the global internet interface.
 
@@ -217,10 +219,10 @@ class WSGIServer:
         if "content-length" in headers:
             env["CONTENT_LENGTH"] = headers.get("content-length")
             body = client.recv(int(env["CONTENT_LENGTH"]))
-            env["wsgi.input"] = io.StringIO(body)  # TODO: Is bytes should be str
+            env["wsgi.input"] = io.StringIO(body)
         else:
             body = client.recv()
-            env["wsgi.input"] = io.StringIO(body)  # TODO: Is bytes should be str
+            env["wsgi.input"] = io.StringIO(body)
         for name, value in headers.items():
             key = "HTTP_" + name.replace("-", "_").upper()
             if key in env:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
@@ -37,6 +37,9 @@ import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 _the_interface = None  # pylint: disable=invalid-name
 
 
+# TODO: Add typing
+
+
 def set_interface(iface):
     """Helper to set the global internet interface"""
     global _the_interface  # pylint: disable=global-statement, invalid-name
@@ -49,6 +52,8 @@ class WSGIServer:
     """
     A simple server that implements the WSGI interface
     """
+
+    # TODO: Add typing
 
     def __init__(self, port=80, debug=False, application=None):
         self.application = application
@@ -66,6 +71,8 @@ class WSGIServer:
         if self._debug:
             print("Max sockets: ", self.MAX_SOCK_NUM)
 
+    # TODO: Add typing
+
     def start(self):
         """
         Starts the server and begins listening for incoming connections.
@@ -81,6 +88,8 @@ class WSGIServer:
         if self._debug:
             ip = _the_interface.pretty_ip(_the_interface.ip_address)
             print("Server available at {0}:{1}".format(ip, self.port))
+
+    # TODO: Add typing
 
     def update_poll(self):
         """
@@ -107,6 +116,8 @@ class WSGIServer:
                 self._client_sock.append(new_sock)
             except RuntimeError:
                 pass
+
+    # TODO: Add typing
 
     def finish_response(self, result, client):
         """
@@ -140,6 +151,8 @@ class WSGIServer:
             client.disconnect()
             client.close()
 
+    # TODO: Add typing
+
     def _start_response(self, status, response_headers):
         """
         The application callable will be given this method as the second param
@@ -152,6 +165,8 @@ class WSGIServer:
         """
         self._response_status = status
         self._response_headers = [("Server", "w5kWSGIServer")] + response_headers
+
+    # TODO: Add typing
 
     def _get_environ(self, client):
         """

--- a/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
@@ -27,7 +27,6 @@ https://www.python.org/dev/peps/pep-0333/
 * Author(s): Matt Costi, Patrick Van Oosterwijck
 """
 # pylint: disable=no-name-in-module
-# from __future__ import annotations
 try:
     from typing import Optional, List, Tuple, Dict
     from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K


### PR DESCRIPTION
Added typing to all modules. Made two small edits to improve typing compatibility.

In `adafruit_wiznet5k.adafruit_wiznet5k_ntp.__init__()` changed `utc: int` to `utc: float` as some time zones are on the half hour. Added `int()` to  `get_time()` to allow for a float argument being passed.

In `adafruit_wiznet5k.adafruit_wiznet5k_dns.__init__()` changed `self._host = 0` to `self._host = b""` to remove a warning about it not having a `to_int()` method. `self._host` is set to a `bytes` object in `gethostbyname()` and is read as a bytes object in `_build_dns_question()` but nowhere else.

I am confident that these changes don't break the code.

There are three other type conflicts that are more complex and have not been addressed.