### PR TITLE
Fixed a TypeError in adafruit_wiznet5k_dns.DNS._build_dns_question()

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -244,7 +244,7 @@ class DNS:
             # append the sz of the section
             self._pkt_buf.append(len(host[i]))
             # append the section data
-            self._pkt_buf += host[i]
+            self._pkt_buf += bytes(host[i], "utf-8")
         # end of the name
         self._pkt_buf.append(0x00)
         # Type A record


### PR DESCRIPTION
closes #71 Fix is `self._pkt_buf += bytes(host[i], "utf-8")`


Code snippet with bug below.

```
adafruit_wiznet5k/adafruit_wiznet5k_dns.py
        
    def _build_dns_question(self) -> None:
        """Build a DNS query."""
        host = self._host.decode("utf-8")
        host = host.split(".")
        # write out each section of host
        for i, _ in enumerate(host):
            # append the sz of the section
            self._pkt_buf.append(len(host[i]))
            # append the section data
            self._pkt_buf += host[i]     # <-------
        # end of the name
        self._pkt_buf.append(0x00)
        # Type A record
        self._pkt_buf.append(htons(TYPE_A) & 0xFF)
        self._pkt_buf.append(htons(TYPE_A) >> 8)
        # Class IN
        self._pkt_buf.append(htons(CLASS_IN) & 0xFF)
        self._pkt_buf.append(htons(CLASS_IN) >> 8)
```

