### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -148,7 +148,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
     def __init__(
         self,
         spi_bus,
-        cs,
+        cs,  # pylint: disable=invalid-name
         reset=None,
         is_dhcp=True,
         mac=DEFAULT_MAC,
@@ -493,8 +493,8 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             if hasattr(data, "from_bytes"):
                 bus_device.write(bytes([data]))  # pylint: disable=no-member
             else:
-                for i, _ in enumerate(data):
-                    bus_device.write(bytes([data[i]]))  # pylint: disable=no-member
+                for data_comp in data:
+                    bus_device.write(bytes([data_comp]))  # pylint: disable=no-member
 
     # Socket-Register API
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -240,11 +240,11 @@ class DNS:
         host = self._host.decode("utf-8")
         host = host.split(".")
         # write out each section of host
-        for i, _ in enumerate(host):
+        for data in host:
             # append the sz of the section
-            self._pkt_buf.append(len(host[i]))
+            self._pkt_buf.append(len(data))
             # append the section data
-            self._pkt_buf += bytes(host[i], "utf-8")
+            self._pkt_buf += bytes(data, "utf-8")
         # end of the name
         self._pkt_buf.append(0x00)
         # Type A record


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
************* Module adafruit_wiznet5k.adafruit_wiznet5k
Error: adafruit_wiznet5k/adafruit_wiznet5k.py:151:8: C0103: Argument name "cs" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
Error: adafruit_wiznet5k/adafruit_wiznet5k.py:497:44: R1736: Unnecessary list index lookup, use '_' instead (unnecessary-list-index-lookup)
************* Module adafruit_wiznet5k.adafruit_wiznet5k_dns
Error: adafruit_wiznet5k/adafruit_wiznet5k_dns.py:245:37: R1736: Unnecessary list index lookup, use '_' instead (unnecessary-list-index-lookup)
Error: adafruit_wiznet5k/adafruit_wiznet5k_dns.py:247:35: R1736: Unnecessary list index lookup, use '_' instead (unnecessary-list-index-lookup)
```