### PR TITLE
Standardise sockets

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -264,11 +264,13 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         :return Union[int, bytes]: a 4 bytearray.
         """
         if self._debug:
-            print("* Get host by name")
+            print(f"* Get host by name : {hostname}")
         if isinstance(hostname, str):
             hostname = bytes(hostname, "utf-8")
         # Return IP assigned by DHCP
-        _dns_client = dns.DNS(self, self._dns, debug=self._debug)
+        _dns_client = dns.DNS(
+            self, self.pretty_ip(bytearray(self._dns)), debug=self._debug
+        )
         ret = _dns_client.gethostbyname(hostname)
         if self._debug:
             print("* Resolved IP: ", ret)

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -978,9 +978,6 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         assert self.link_status, "Ethernet cable disconnected!"
         assert socket_num <= self.max_sockets, "Provided socket exceeds max_sockets."
-        status = 0
-        ret = 0
-        free_size = 0
         if len(buffer) > SOCK_SIZE:
             ret = SOCK_SIZE
         else:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -15,6 +15,8 @@ ethernet modules.
 """
 from __future__ import annotations
 
+import gc
+
 try:
     from typing import TYPE_CHECKING, Union, Tuple
 
@@ -54,7 +56,7 @@ class DNS:
         self,
         iface: WIZNET5K,
         dns_address: Union[str, Tuple[int, int, int, int]],
-        debug: bool = False,
+        debug: bool = True,
     ) -> None:
         """
         :param adafruit_wiznet5k.WIZNET5K: Ethernet network connection.
@@ -66,7 +68,6 @@ class DNS:
         socket.set_interface(iface)
         self._sock = socket.socket(type=socket.SOCK_DGRAM)
         self._sock.settimeout(1)
-
         self._dns_server = dns_address
         self._host = b""
         self._request_id = 0  # request identifier
@@ -80,6 +81,7 @@ class DNS:
 
         :return Union[int, bytes] The IPv4 address if successful, -1 otherwise.
         """
+
         if self._dns_server is None:
             return INVALID_SERVER
         self._host = hostname
@@ -88,7 +90,7 @@ class DNS:
         self._build_dns_question()
 
         # Send DNS request packet
-        self._sock.bind((None, DNS_PORT))
+        self._sock.bind(("", DNS_PORT))
         self._sock.connect((self._dns_server, DNS_PORT))
         if self._debug:
             print("* DNS: Sending request packet...")
@@ -225,6 +227,7 @@ class DNS:
                 print("* DNS ERROR: Unexpected Data Length: ", data_len)
             return -1
         ptr += 2
+        gc.collect()
         # Return address
         return self._pkt_buf[ptr : ptr + 4]
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -117,16 +117,16 @@ class DNS:
         """
         # wait for a response
         start_time = time.monotonic()
-        packet_sz = self._sock.available()
+        packet_sz = self._sock._available()  # pylint: disable=protected-access
         while packet_sz <= 0:
-            packet_sz = self._sock.available()
+            packet_sz = self._sock._available()  # pylint: disable=protected-access
             if (time.monotonic() - start_time) > 1.0:
                 if self._debug:
                     print("* DNS ERROR: Did not receive DNS response!")
                 return -1
             time.sleep(0.05)
         # recv packet into buf
-        self._pkt_buf = self._sock.recv()
+        self._pkt_buf = self._sock.recv(512)  # > UDP payload length
 
         if self._debug:
             print("DNS Packet Received: ", self._pkt_buf)

--- a/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_ntp.py
@@ -71,7 +71,7 @@ class NTP:
         self._sock.bind((None, 50001))
         self._sock.sendto(self._pkt_buf_, (self._ntp_server, 123))
         while True:
-            data = self._sock.recv()
+            data = self._sock.recv(64)  # NTP returns a 48 byte message.
             if data:
                 sec = data[40:44]
                 int_cal = int.from_bytes(sec, "big")

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -237,19 +237,6 @@ class socket:
         """
         return _the_interface.remote_ip(self._socknum)
 
-    def _inet_aton(self, ip_string: str) -> bytearray:
-        """
-        Convert an IPv4 address from dotted-quad string format.
-
-        :param str ip_string: IPv4 address (a string of the form '255.255.255.255').
-
-        :return bytearray: IPv4 address as a 4 byte bytearray.
-        """
-        self._buffer = b""
-        self._buffer = [int(item) for item in ip_string.split(".")]
-        self._buffer = bytearray(self._buffer)
-        return self._buffer
-
     def bind(self, address: Tuple[Optional[str], int]) -> None:
         """Bind the socket to address. The socket must not already be bound.
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -289,18 +289,20 @@ class socket:
         )
 
     def bind(self, address: Tuple[Optional[str], int]) -> None:
-        """Bind the socket to address. The socket must not already be bound.
+        """
+        Bind the socket to address. The socket must not already be bound.
 
-        The hardware sockets on WIZNET5K systems all share the same IPv4 address that
-        was assigned at startup. Ports can only be bound to this address.
+        The hardware sockets on WIZNET5K systems all share the same IPv4 address. The
+        address is assigned at startup. Ports can only be bound to this address.
 
         :param Tuple[Optional[str], int] address: Address as a (host, port) tuple.
 
         :raises ValueError: If the IPv4 address specified is not the address
             assigned to the WIZNET5K interface.
         """
-        if self._listen_port:
-            raise ConnectionError("The socket is already bound.")
+        # Check is disabled to allow socket.accept to swap sockets.
+        # if self._listen_port:
+        #     raise ConnectionError("The socket is already bound.")
         if address[0]:
             if gethostbyname(address[0]) != _the_interface.pretty_ip(
                 _the_interface.ip_address

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -373,15 +373,27 @@ class socket:
         gc.collect()
         return bytes_sent
 
-    def sendto(self, data: bytearray, address: [Tuple[str, int]]) -> None:
+    # def sendto(self, data: bytearray, address: [Tuple[str, int]]) -> int:
+
+    def sendto(self, data: bytearray, *flags_and_or_address: any) -> int:
         """
         Connect to a remote socket and send data.
 
         :param bytearray data: Data to send to the socket.
-        :param tuple address: Remote socket as a (host, port) tuple.
+
+        Either:
+        :param [Tuple[str, int]] address: Remote socket as a (host, port) tuple.
+
+        Or:
+        :param int flags: Not implemented, kept for compatibility.
+        :param Tuple[int, Tuple(str, int)] address: Remote socket as a (host, port) tuple
         """
-        # TODO: Implement optional flags.
-        # TODO: Should return number of bytes sent (can of worms opened)
+        # May be calle with (data, address) or (data, flags, address)
+        other_args = list(flags_and_or_address)
+        if len(other_args) in (1, 2):
+            address = other_args[-1]
+        else:
+            raise ValueError("Incorrect number of arguments, should be 2 or 3.")
         self.connect(address)
         return self.send(data)
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -146,8 +146,6 @@ class socket:
         type: int = SOCK_STREAM,
         proto: int = 0,
         fileno: Optional[int] = None,
-        # TODO: Remove socknum
-        socknum: Optional[int] = None,
     ) -> None:
         """
         :param int family: Socket address (and protocol) family, defaults to AF_INET.

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -96,7 +96,7 @@ def getaddrinfo(
     :return List[Tuple[int, int, int, str, Tuple[str, int]]]: Address info entries.
     """
     if not isinstance(port, int):
-        raise RuntimeError("Port must be an integer")
+        raise ValueError("Port must be an integer")
     octets = host.split(".", 3)
     if len(octets) == 4 and "".join(octets).isdigit():
         for octet in octets:
@@ -118,23 +118,6 @@ def gethostbyname(hostname: str) -> str:
     address = _the_interface.get_host_by_name(hostname)
     address = "{}.{}.{}.{}".format(address[0], address[1], address[2], address[3])
     return address
-
-
-def _is_ipv4(host: str) -> bool:
-    """
-    Check if a hostname is an IPv4 address (a string of the form '0.0.0.0').
-
-    :param str host: Hostname to check.
-
-    :return bool:
-    """
-    octets = host.split(".", 3)
-    if len(octets) != 4 or not "".join(octets).isdigit():
-        return False
-    for octet in octets:
-        if int(octet) > 255:
-            return False
-    return True
 
 
 # pylint: disable=invalid-name, too-many-public-methods

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -228,14 +228,15 @@ class socket:
             self.close()
         return result
 
-    def getpeername(self) -> Union[str, bytearray]:
+    def getpeername(self) -> Tuple[str, int]:
         """
         Return the remote address to which the socket is connected.
 
-        :return Union[str, bytearray]: An IPv4 address (a string of the form '255.255.255.255').
-            An error may return a bytearray.
+        :return Tuple[str, int]: IPv4 address and port the socket is connected to.
         """
-        return _the_interface.remote_ip(self._socknum)
+        return _the_interface.remote_ip(self._socknum), _the_interface.remote_port(
+            self._socknum
+        )
 
     def bind(self, address: Tuple[Optional[str], int]) -> None:
         """Bind the socket to address. The socket must not already be bound.

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -97,9 +97,14 @@ def getaddrinfo(
     """
     if not isinstance(port, int):
         raise RuntimeError("Port must be an integer")
-    if is_ipv4(host):
-        return [(AF_INET, socktype, proto, "", (host, port))]
-    return [(AF_INET, socktype, proto, "", (gethostbyname(host), port))]
+    octets = host.split(".", 3)
+    if len(octets) == 4 and "".join(octets).isdigit():
+        for octet in octets:
+            if int(octet) > 255:
+                pass
+    else:
+        host = gethostbyname(host)
+    return [(AF_INET, socktype, proto, "", (host, port))]
 
 
 def gethostbyname(hostname: str) -> str:
@@ -115,7 +120,7 @@ def gethostbyname(hostname: str) -> str:
     return address
 
 
-def is_ipv4(host: str) -> bool:
+def _is_ipv4(host: str) -> bool:
     """
     Check if a hostname is an IPv4 address (a string of the form '0.0.0.0').
 

--- a/examples/wiznet5k_simpleserver.py
+++ b/examples/wiznet5k_simpleserver.py
@@ -18,7 +18,7 @@ cs = digitalio.DigitalInOut(board.D10)
 spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # Initialize ethernet interface
-eth = WIZNET5K(spi_bus, cs, is_dhcp=False)
+eth = WIZNET5K(spi_bus, cs, is_dhcp=True)
 
 # Initialize a socket for our server
 socket.set_interface(eth)


### PR DESCRIPTION
Updated `adafruit_wiznet5k_socket.py` to match as closely as possible CPython `socket`. Functions that exist in Cpython `socket` have matching parameters and return types. Functions that exist in wiznet5k `socket` but not in Cpython `socket` were renamed with a leading `_` except `socket.setinterface`.

Main differences:

- `flags` still not implemented, not planned to be.
- `socket.bind` can only bind to the IP address that the Wiznet chip was initialized with. All the hardware sockets share this single address. Changing the IP address after initialization leaves previously connected sockets in an unknown state. Raises `ValueError` if the IP address does not match.
- `socket.bind` should raise an exception if the socket is already bound. Making this check currently causes `socket.accept` to fail because it calls 'bind' on a bound socket.

Not attempted, TODO: at a later date:

- Raise appropriate exceptions from `adafruit_wiznet5k.py`
- Refactor modules to stop calling `socket` nonstandard functions then remove nonstandard functions.

This has been tested by running `simpletest.py` and `simpleserver.py`.

More testing would be appreciated.
