### PR TITLE
Update SimpleServer example to accept >1 connection

### DIFF
--- a/examples/client_for_wiznet5k_simpleserver.py
+++ b/examples/client_for_wiznet5k_simpleserver.py
@@ -3,7 +3,8 @@ import socket
 import time
 
 print("A simple client for the wiznet5k_simpleserver.py example in this directory")
-print("Run this on any device connected to the same network as the server, after editing this script with the correct HOST & PORT\n")
+print("Run this on any device connected to the same network as the server, after "
+      "editing this script with the correct HOST & PORT\n")
 # Or, use any TCP-based client that can easily send 1024 bytes. For example:
 #     python -c 'print("1234"*256)' | nc 192.168.10.1 50007
 

--- a/examples/client_for_wiznet5k_simpleserver.py
+++ b/examples/client_for_wiznet5k_simpleserver.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import socket
+import time
+
+print("A simple client for the wiznet5k_simpleserver.py example in this directory")
+print("Run this on any device connected to the same network as the server, after editing this script with the correct HOST & PORT\n")
+# Or, use any TCP-based client that can easily send 1024 bytes. For example:
+#     python -c 'print("1234"*256)' | nc 192.168.10.1 50007
+
+
+# edit host and port to match server
+HOST = "192.168.10.1"
+PORT = 50007
+TIMEOUT = 10
+INTERVAL = 5
+MAXBUF = 1024
+
+while True:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(TIMEOUT)
+    print(f"Connecting to {HOST}:{PORT}")
+    s.connect((HOST, PORT))
+    # wiznet5k_simpleserver.py wants exactly 1024 bytes
+    size = s.send(b'A5'*512)
+    print("Sent", size, "bytes")
+    buf = s.recv(MAXBUF)
+    print('Received', buf)
+    s.close()
+    time.sleep(INTERVAL)

--- a/examples/wiznet5k_cpython_client_for_simpleserver.py
+++ b/examples/wiznet5k_cpython_client_for_simpleserver.py
@@ -1,10 +1,20 @@
+# SPDX-FileCopyrightText: 2023 ladyada
+#
+# SPDX-License-Identifier: MIT
 #!/usr/bin/env python3
+
+"""
+This example client runs on CPython and connects to / sends data to the
+simpleserver example.
+"""
 import socket
 import time
 
 print("A simple client for the wiznet5k_simpleserver.py example in this directory")
-print("Run this on any device connected to the same network as the server, after "
-      "editing this script with the correct HOST & PORT\n")
+print(
+    "Run this on any device connected to the same network as the server, after "
+    "editing this script with the correct HOST & PORT\n"
+)
 # Or, use any TCP-based client that can easily send 1024 bytes. For example:
 #     python -c 'print("1234"*256)' | nc 192.168.10.1 50007
 
@@ -22,9 +32,9 @@ while True:
     print(f"Connecting to {HOST}:{PORT}")
     s.connect((HOST, PORT))
     # wiznet5k_simpleserver.py wants exactly 1024 bytes
-    size = s.send(b'A5'*512)
+    size = s.send(b"A5" * 512)
     print("Sent", size, "bytes")
     buf = s.recv(MAXBUF)
-    print('Received', buf)
+    print("Received", buf)
     s.close()
     time.sleep(INTERVAL)

--- a/examples/wiznet5k_simpleserver.py
+++ b/examples/wiznet5k_simpleserver.py
@@ -29,9 +29,12 @@ server.bind((server_ip, server_port))  # Bind to IP and Port
 server.listen()  # Begin listening for incoming clients
 
 while True:
+    print(f"Accepting connections on {server_ip}:{server_port}")
     conn, addr = server.accept()  # Wait for a connection from a client.
+    print(f"Connection accepted from {addr}, reading exactly 1024 bytes from client")
     with conn:
         data = conn.recv(1024)
         if data:  # Wait for receiving data
             print(data)
             conn.send(data)  # Echo message back to client
+    print("Connection closed")

--- a/examples/wiznet5k_simpleserver.py
+++ b/examples/wiznet5k_simpleserver.py
@@ -28,8 +28,8 @@ server_port = 50007  # Port to listen on
 server.bind((server_ip, server_port))  # Bind to IP and Port
 server.listen()  # Begin listening for incoming clients
 
-conn, addr = server.accept()  # Wait for a connection from a client.
 while True:
+    conn, addr = server.accept()  # Wait for a connection from a client.
     with conn:
         data = conn.recv(1024)
         if data:  # Wait for receiving data

--- a/examples/wiznet5k_simpleserver.py
+++ b/examples/wiznet5k_simpleserver.py
@@ -18,12 +18,12 @@ cs = digitalio.DigitalInOut(board.D10)
 spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # Initialize ethernet interface
-eth = WIZNET5K(spi_bus, cs, is_dhcp=False)
+eth = WIZNET5K(spi_bus, cs, is_dhcp=True)
 
 # Initialize a socket for our server
 socket.set_interface(eth)
 server = socket.socket()  # Allocate socket for the server
-server_ip = "192.168.10.1"  # IP address of server
+server_ip = eth.pretty_ip(eth.ip_address)  # IP address of server
 server_port = 50007  # Port to listen on
 server.bind((server_ip, server_port))  # Bind to IP and Port
 server.listen()  # Begin listening for incoming clients


### PR DESCRIPTION
While watching @FoamyGuy [stream](https://youtu.be/ipIN_g8mRXc?t=6657), I noticed the server code he was using only allowed a single client connection.

This moves the `accept()` call into the `while True` loop, leaving the server accepting connections as long as the `server` socket is valid.

My understanding of the existing example code:

1. Binds a socket to the hardcoded IP + port combo
2. Listens for incoming connections
3. Accepts a single connection
4. Enters `while True` loop
5. `recv` up to 1024 bytes
6. prints & echos those bytes back to the client
7. closes `conn` in [__exit__](https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k/blob/1b8ff4e48931722133a97090bce01c4795d64803/adafruit_wiznet5k/adafruit_wiznet5k_socket.py#L178-L180)
8. loops forever with closed `conn` socket, [receiving nothing and printing nothing](https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k/blob/1b8ff4e48931722133a97090bce01c4795d64803/adafruit_wiznet5k/adafruit_wiznet5k_socket.py#L400-L401) (this is undesirable)
9. microcontroller running the server must be restarted in order to receive a new connection.

After this PR, I expect the example code to:

1. Binds a socket to the hardcoded IP + port combo
2. Listens for incoming connections
3. Enters `while True` loop
4. Accepts a connection
5. `recv` up to 1024 bytes
6. prints & echos those bytes back to the client
7. close connection to that client
8. return to step 4, ready for another client to connect.

