### PR TITLE
Fix for issue #108 - Make sure the buffer is large enough before ever…

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -86,7 +86,8 @@ _LEASE_TIME = 51
 _OPT_END = 255
 
 # Packet buffer
-_BUFF = bytearray(318)
+_BUFF_SIZE = const(318)
+_BUFF = bytearray(_BUFF_SIZE)
 
 
 class DHCP:
@@ -166,7 +167,7 @@ class DHCP:
         :param float time_elapsed: Number of seconds elapsed since DHCP process started
         :param bool renew: Set True for renew and rebind, defaults to False
         """
-        _BUFF[:] = b"\x00" * len(_BUFF)
+        _BUFF = bytearray(_BUFF_SIZE)
         # OP
         _BUFF[0] = _DHCP_BOOT_REQUEST
         # HTYPE


### PR DESCRIPTION
Added a const value for the buffer size.
Used that value for both the initial buffer allocation, and the buffer re-initialization in preparation for sending packets.

This prevents a buffer overflow when building the DHCPREQUEST packet because the buffer appears to have shrunk while processing the DHCPOFFER reply.