### PR TITLE
Added explicit soft reset for w5500 initialisation.

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -481,6 +481,11 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             """
             self._chip_type = "w5500"
             # assert self.sw_reset() == 0, "Chip not reset properly!"
+            self._write_mr(0x80)
+            time.sleep(0.05)
+            if self._read_mr()[0] & 0x80:
+                return False
+
             self._write_mr(0x08)
             # assert self._read_mr()[0] == 0x08, "Expected 0x08."
             if self._read_mr()[0] != 0x08:


### PR DESCRIPTION
Fixes #109 by explicitly resetting the w5500 during initialisation. Tested on w5500 and w5100s for 10 `ctrl-D` soft resets each without raising an exception.