### PR TITLE
Fix DHCP socket leak

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -156,7 +156,7 @@ _SOCK_MASK = const(0x7FF)
 _MR_RST = const(0x80)  # Mode Register RST
 # Socket mode register
 _SNMR_CLOSE = const(0x00)
-SNMR_TCP = const(0x21)
+_SNMR_TCP = const(0x21)
 SNMR_UDP = const(0x02)
 _SNMR_IPRAW = const(0x03)
 _SNMR_MACRAW = const(0x04)
@@ -492,7 +492,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
     # *** Public Socket Methods ***
 
-    def socket_available(self, socket_num: int, sock_type: int = SNMR_TCP) -> int:
+    def socket_available(self, socket_num: int, sock_type: int = _SNMR_TCP) -> int:
         """
         Number of bytes available to be read from the socket.
 
@@ -514,7 +514,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         self._sock_num_in_range(socket_num)
 
         number_of_bytes = self._get_rx_rcv_size(socket_num)
-        if self.read_snsr(socket_num) == SNMR_UDP:
+        if self._read_snsr(socket_num) == SNMR_UDP:
             number_of_bytes -= 8  # Subtract UDP header from packet size.
         if number_of_bytes < 0:
             raise ValueError("Negative number of bytes found on socket.")
@@ -533,14 +533,14 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
         :return int: The connection status.
         """
-        return self.read_snsr(socket_num)
+        return self._read_snsr(socket_num)
 
     def socket_connect(
         self,
         socket_num: int,
         dest: IpAddress4Raw,
         port: int,
-        conn_mode: int = SNMR_TCP,
+        conn_mode: int = _SNMR_TCP,
     ) -> int:
         """
         Open and verify a connection from a socket to a destination IPv4 address
@@ -567,11 +567,11 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         # initialize a socket and set the mode
         self.socket_open(socket_num, conn_mode=conn_mode)
         # set socket destination IP and port
-        self.write_sndipr(socket_num, dest)
-        self.write_sndport(socket_num, port)
-        self.write_sncr(socket_num, _CMD_SOCK_CONNECT)
+        self._write_sndipr(socket_num, dest)
+        self._write_sndport(socket_num, port)
+        self._write_sncr(socket_num, _CMD_SOCK_CONNECT)
 
-        if conn_mode == SNMR_TCP:
+        if conn_mode == _SNMR_TCP:
             # wait for tcp connection establishment
             while self.socket_status(socket_num) != SNSR_SOCK_ESTABLISHED:
                 time.sleep(0.001)
@@ -638,7 +638,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         WIZNET5K._sockets_reserved[socket_number - 1] = False
 
     def socket_listen(
-        self, socket_num: int, port: int, conn_mode: int = SNMR_TCP
+        self, socket_num: int, port: int, conn_mode: int = _SNMR_TCP
     ) -> None:
         """
         Listen on a socket's port.
@@ -665,7 +665,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         self.socket_open(socket_num, conn_mode=conn_mode)
         self.src_port = 0
         # Send listen command
-        self.write_sncr(socket_num, _CMD_SOCK_LISTEN)
+        self._write_sncr(socket_num, _CMD_SOCK_LISTEN)
         # Wait until ready
         status = SNSR_SOCK_CLOSED
         while status not in (
@@ -673,7 +673,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             SNSR_SOCK_ESTABLISHED,
             _SNSR_SOCK_UDP,
         ):
-            status = self.read_snsr(socket_num)
+            status = self._read_snsr(socket_num)
             if status == SNSR_SOCK_CLOSED:
                 raise RuntimeError("Listening socket closed.")
 
@@ -703,7 +703,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         )
         return next_socknum, (dest_ip, dest_port)
 
-    def socket_open(self, socket_num: int, conn_mode: int = SNMR_TCP) -> None:
+    def socket_open(self, socket_num: int, conn_mode: int = _SNMR_TCP) -> None:
         """
         Open an IP socket.
 
@@ -720,7 +720,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         self._sock_num_in_range(socket_num)
         self._check_link_status()
         debug_msg("*** Opening socket {}".format(socket_num), self._debug)
-        if self.read_snsr(socket_num) not in (
+        if self._read_snsr(socket_num) not in (
             SNSR_SOCK_CLOSED,
             SNSR_SOCK_TIME_WAIT,
             SNSR_SOCK_FIN_WAIT,
@@ -732,22 +732,22 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         debug_msg("* Opening W5k Socket, protocol={}".format(conn_mode), self._debug)
         time.sleep(0.00025)
 
-        self.write_snmr(socket_num, conn_mode)
+        self._write_snmr(socket_num, conn_mode)
         self.write_snir(socket_num, 0xFF)
 
         if self.src_port > 0:
             # write to socket source port
-            self.write_sock_port(socket_num, self.src_port)
+            self._write_sock_port(socket_num, self.src_port)
         else:
             s_port = randint(49152, 65535)
             while s_port in self._src_ports_in_use:
                 s_port = randint(49152, 65535)
-            self.write_sock_port(socket_num, s_port)
+            self._write_sock_port(socket_num, s_port)
             self._src_ports_in_use[socket_num] = s_port
 
         # open socket
-        self.write_sncr(socket_num, _CMD_SOCK_OPEN)
-        if self.read_snsr(socket_num) not in [_SNSR_SOCK_INIT, _SNSR_SOCK_UDP]:
+        self._write_sncr(socket_num, _CMD_SOCK_OPEN)
+        if self._read_snsr(socket_num) not in [_SNSR_SOCK_INIT, _SNSR_SOCK_UDP]:
             raise RuntimeError("Could not open socket in TCP or UDP mode.")
 
     def socket_close(self, socket_num: int) -> None:
@@ -760,14 +760,14 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         debug_msg("*** Closing socket {}".format(socket_num), self._debug)
         self._sock_num_in_range(socket_num)
-        self.write_sncr(socket_num, _CMD_SOCK_CLOSE)
+        self._write_sncr(socket_num, _CMD_SOCK_CLOSE)
         debug_msg("  Waiting for socket to close…", self._debug)
         timeout = time.monotonic() + 5.0
-        while self.read_snsr(socket_num) != SNSR_SOCK_CLOSED:
+        while self._read_snsr(socket_num) != SNSR_SOCK_CLOSED:
             if time.monotonic() > timeout:
                 raise RuntimeError(
                     "Wiznet5k failed to close socket, status = {}.".format(
-                        self.read_snsr(socket_num)
+                        self._read_snsr(socket_num)
                     )
                 )
             time.sleep(0.0001)
@@ -783,7 +783,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         debug_msg("*** Disconnecting socket {}".format(socket_num), self._debug)
         self._sock_num_in_range(socket_num)
-        self.write_sncr(socket_num, _CMD_SOCK_DISCON)
+        self._write_sncr(socket_num, _CMD_SOCK_DISCON)
 
     def socket_read(self, socket_num: int, length: int) -> Tuple[int, bytes]:
         """
@@ -819,7 +819,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             # After reading the received data, update Sn_RX_RD register.
             pointer = (pointer + bytes_on_socket) & 0xFFFF
             self._write_snrx_rd(socket_num, pointer)
-            self.write_sncr(socket_num, _CMD_SOCK_RECV)
+            self._write_sncr(socket_num, _CMD_SOCK_RECV)
         else:
             # no data on socket
             if self._read_snmr(socket_num) in (
@@ -906,7 +906,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         # update sn_tx_wr to the value + data size
         pointer = (pointer + bytes_to_write) & 0xFFFF
         self._write_sntx_wr(socket_num, pointer)
-        self.write_sncr(socket_num, _CMD_SOCK_SEND)
+        self._write_sncr(socket_num, _CMD_SOCK_SEND)
 
         # check data was  transferred correctly
         while not self.read_snir(socket_num) & _SNIR_SEND_OK:
@@ -1175,18 +1175,18 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             )
         return bytes(data)
 
-    def write_sndipr(self, sock: int, ip_addr: bytes) -> None:
+    def _write_sndipr(self, sock: int, ip_addr: bytes) -> None:
         """Write to socket destination IP Address."""
         for offset, value in enumerate(ip_addr):
             self._write_socket_register(
                 sock, _REG_SNDIPR[self._chip_type] + offset, value
             )
 
-    def write_sndport(self, sock: int, port: int) -> None:
+    def _write_sndport(self, sock: int, port: int) -> None:
         """Write to socket destination port."""
         self._write_two_byte_sock_reg(sock, _REG_SNDPORT[self._chip_type], port)
 
-    def read_snsr(self, sock: int) -> int:
+    def _read_snsr(self, sock: int) -> int:
         """Read Socket n Status Register."""
         return self._read_socket_register(sock, _REG_SNSR[self._chip_type])
 
@@ -1202,15 +1202,15 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """Read the socket MR register."""
         return self._read_socket_register(sock, _REG_SNMR)
 
-    def write_snmr(self, sock: int, protocol: int) -> None:
+    def _write_snmr(self, sock: int, protocol: int) -> None:
         """Write to Socket n Mode Register."""
         self._write_socket_register(sock, _REG_SNMR, protocol)
 
-    def write_sock_port(self, sock: int, port: int) -> None:
+    def _write_sock_port(self, sock: int, port: int) -> None:
         """Write to the socket port number."""
         self._write_two_byte_sock_reg(sock, _REG_SNPORT[self._chip_type], port)
 
-    def write_sncr(self, sock: int, data: int) -> None:
+    def _write_sncr(self, sock: int, data: int) -> None:
         """Write to socket command register."""
         self._write_socket_register(sock, _REG_SNCR[self._chip_type], data)
         # Wait for command to complete before continuing.

--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -1057,6 +1057,11 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         if not self.link_status:
             raise ConnectionError("The Ethernet connection is down.")
 
+    @staticmethod
+    def _read_socket_reservations() -> list[int]:
+        """Return the list of reserved sockets."""
+        return WIZNET5K._sockets_reserved
+
     def _read_mr(self) -> int:
         """Read from the Mode Register (MR)."""
         return int.from_bytes(self._read(_REG_MR[self._chip_type], 0x00), "big")
@@ -1181,6 +1186,10 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
             self._write_socket_register(
                 sock, _REG_SNDIPR[self._chip_type] + offset, value
             )
+
+    def _read_sndport(self, sock: int) -> int:
+        """Read socket destination port."""
+        return self._read_two_byte_sock_reg(sock, _REG_SNDPORT[self._chip_type])
 
     def _write_sndport(self, sock: int, port: int) -> None:
         """Write to socket destination port."""

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -366,9 +366,8 @@ class DHCP:
             raise ValueError(
                 "FSM can only send messages while in SELECTING or REQUESTING states."
             )
+        message_length = self._generate_dhcp_message(message_type=msg_type_out)
         for attempt in range(4):  # Initial attempt plus 3 retries.
-            message_length = self._generate_dhcp_message(message_type=msg_type_out)
-
             if self._renew:
                 dhcp_server_address = self.dhcp_server_ip
             else:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -197,7 +197,6 @@ class DHCP:
         state machine INIT state."""
         debug_msg("Resetting DHCP state machine.", self._debug)
         self._socket_release()
-        self._dhcp_connection_setup()
         self.dhcp_server_ip = _BROADCAST_SERVER_ADDR
         self._eth.ifconfig = (
             _UNASSIGNED_IP_ADDR,
@@ -366,6 +365,7 @@ class DHCP:
             raise ValueError(
                 "FSM can only send messages while in SELECTING or REQUESTING states."
             )
+        self._dhcp_connection_setup()
         message_length = self._generate_dhcp_message(message_type=msg_type_out)
         for attempt in range(4):  # Initial attempt plus 3 retries.
             if self._renew:
@@ -431,7 +431,6 @@ class DHCP:
             if self._dhcp_state == _STATE_RENEWING:
                 debug_msg("FSM state is RENEWING.", self._debug)
                 self._renew = "renew"
-                self._dhcp_connection_setup()
                 self._start_time = time.monotonic()
                 self._dhcp_state = _STATE_REQUESTING
 
@@ -439,7 +438,6 @@ class DHCP:
                 debug_msg("FSM state is REBINDING.", self._debug)
                 self._renew = "rebind"
                 self.dhcp_server_ip = _BROADCAST_SERVER_ADDR
-                self._dhcp_connection_setup()
                 self._start_time = time.monotonic()
                 self._dhcp_state = _STATE_REQUESTING
 

--- a/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dhcp.py
@@ -147,7 +147,6 @@ class DHCP:
 
         # Set socket interface
         self._eth = eth
-        self._wiz_sock = None
 
         # DHCP state machine
         self._dhcp_state = _STATE_INIT
@@ -211,45 +210,6 @@ class DHCP:
         self._increment_transaction_id()
         self._start_time = time.monotonic()
 
-    def _socket_release(self) -> None:
-        """Close the socket if it exists."""
-        debug_msg("Releasing socket.", self._debug)
-        if self._wiz_sock is not None:
-            self._eth.socket_close(self._wiz_sock)
-            self._wiz_sock = None
-        debug_msg("  Socket released.", self._debug)
-
-    def _dhcp_connection_setup(self, timeout: float = 5.0) -> None:
-        """Initialise a UDP socket.
-
-        Attempt to initialise a UDP socket. If the finite state machine (FSM) is in
-        blocking mode, repeat failed attempts until a socket is initialised or
-        the operation times out, then raise an exception. If the FSM is in non-blocking
-        mode, ignore the error and return.
-
-        :param int timeout: Time to keep retrying if the FSM is in blocking mode.
-            Defaults to 5.
-
-        :raises TimeoutError: If the FSM is in blocking mode and a socket cannot be
-            initialised.
-        """
-        stop_time = time.monotonic() + timeout
-        debug_msg("Setting up connection for DHCP.", self._debug)
-        while self._wiz_sock is None and time.monotonic() < stop_time:
-            self._wiz_sock = self._eth.get_socket()
-            if self._wiz_sock == 0xFF:
-                self._wiz_sock = None
-        while time.monotonic() < stop_time:
-            self._eth.write_snmr(self._wiz_sock, 0x02)  # Set UDP connection
-            self._eth.write_sock_port(self._wiz_sock, 68)  # Set DHCP client port.
-            self._eth.write_sncr(self._wiz_sock, 0x01)  # Open the socket.
-            if self._eth.read_snsr(self._wiz_sock) == 0x22:
-                self._eth.write_sndport(2, _DHCP_SERVER_PORT)
-                debug_msg("+ Connection OK, port set.", self._debug)
-                return
-        self._wiz_sock = None
-        raise RuntimeError("Unable to initialize UDP socket.")
-
     def _increment_transaction_id(self) -> None:
         """Increment the transaction ID and roll over from 0x7fffffff to 0."""
         debug_msg("Incrementing transaction ID", self._debug)
@@ -278,7 +238,7 @@ class DHCP:
         delay = 2**attempt * interval + randint(-1, 1) + time.monotonic()
         return delay
 
-    def _receive_dhcp_response(self, timeout: float) -> int:
+    def _receive_dhcp_response(self, socket_num: int, timeout: float) -> int:
         """
         Receive data from the socket in response to a DHCP query.
 
@@ -288,23 +248,22 @@ class DHCP:
         If the packet is too short, it is discarded and zero is returned. The
         maximum packet size is limited by the size of the global buffer.
 
-        :param float timeout: time.monotonic at which attempt should timeout.
+        :param int socket_num: Socket to read from.
+        :param float timeout: time.monotonic at which attempt should time out.
 
         :returns int: The number of bytes stored in the global buffer.
         """
         debug_msg("Receiving a DHCP response.", self._debug)
         while time.monotonic() < timeout:
             # DHCP returns the query plus additional data. The query length is 236 bytes.
-            if self._eth.socket_available(self._wiz_sock, _SNMR_UDP) > 236:
-                bytes_count, bytes_read = self._eth.read_udp(
-                    self._wiz_sock, _BUFF_LENGTH
-                )
+            if self._eth.socket_available(socket_num, _SNMR_UDP) > 236:
+                bytes_count, bytes_read = self._eth.read_udp(socket_num, _BUFF_LENGTH)
                 _BUFF[:bytes_count] = bytes_read
                 debug_msg("Received {} bytes".format(bytes_count), self._debug)
                 del bytes_read
                 gc.collect()
                 return bytes_count
-        raise TimeoutError("No DHCP response received.")
+        return 0  # No bytes received.
 
     def _process_messaging_states(self, *, message_type: int):
         """
@@ -355,6 +314,7 @@ class DHCP:
         :raises TimeoutError: If the FSM is in blocking mode and no valid response has
             been received before the timeout expires.
         """
+        # pylint: disable=too-many-branches
         debug_msg("Processing SELECTING or REQUESTING state.", self._debug)
         if self._dhcp_state == _STATE_SELECTING:
             msg_type_out = _DHCP_DISCOVER
@@ -364,40 +324,53 @@ class DHCP:
             raise ValueError(
                 "FSM can only send messages while in SELECTING or REQUESTING states."
             )
-        self._dhcp_connection_setup()
-        message_length = self._generate_dhcp_message(message_type=msg_type_out)
-        for attempt in range(4):  # Initial attempt plus 3 retries.
-            if self._renew:
-                dhcp_server_address = self.dhcp_server_ip
-            else:
-                dhcp_server_address = _BROADCAST_SERVER_ADDR
-            self._eth.write_sndipr(self._wiz_sock, dhcp_server_address)
-            self._eth.write_sndport(self._wiz_sock, _DHCP_SERVER_PORT)
-            self._eth.socket_write(self._wiz_sock, _BUFF[:message_length])
-            next_resend = self._next_retry_time(attempt=attempt)
-            while time.monotonic() < next_resend:
-                if self._receive_dhcp_response(next_resend):
-                    try:
-                        msg_type_in = self._parse_dhcp_response()
+        debug_msg("Setting up connection for DHCP.", self._debug)
+        if self._renew:
+            dhcp_server = self.dhcp_server_ip
+        else:
+            dhcp_server = _BROADCAST_SERVER_ADDR
+        sock_num = None
+        deadline = time.monotonic() + 5.0
+        try:
+            while sock_num is None:
+                sock_num = self._eth.get_socket()
+                if sock_num == 0xFF:
+                    sock_num = None
+                if time.monotonic() > deadline:
+                    raise RuntimeError("Unable to initialize UDP socket.")
+
+            self._eth.src_port = 68
+            self._eth.socket_connect(
+                sock_num, dhcp_server, _DHCP_SERVER_PORT, conn_mode=0x02
+            )
+            self._eth.src_port = 0
+
+            message_length = self._generate_dhcp_message(message_type=msg_type_out)
+            for attempt in range(4):  # Initial attempt plus 3 retries.
+                self._eth.socket_write(sock_num, _BUFF[:message_length])
+                next_resend = self._next_retry_time(attempt=attempt)
+                while time.monotonic() < next_resend:
+                    if self._receive_dhcp_response(sock_num, next_resend):
+                        try:
+                            msg_type_in = self._parse_dhcp_response()
+                            debug_msg(
+                                "Received message type {}".format(msg_type_in),
+                                self._debug,
+                            )
+                            return msg_type_in
+                        except ValueError as error:
+                            debug_msg(error, self._debug)
+                    if not self._blocking or self._renew:
                         debug_msg(
-                            "Received message type {}".format(msg_type_in), self._debug
+                            "No message, FSM is nonblocking or renewing, exiting loop.",
+                            self._debug,
                         )
-                        return msg_type_in
-                    except ValueError as error:
-                        debug_msg(error, self._debug)
-                    finally:
-                        self._socket_release()
-                if not self._blocking or self._renew:
-                    debug_msg(
-                        "No message, FSM is nonblocking or renewing, exiting loop.",
-                        self._debug,
-                    )
-                    self._socket_release()
-                    return 0  # Did not receive a response in a single attempt.
-        self._socket_release()
-        raise TimeoutError(
-            "No response from DHCP server after {} retries.".format(attempt)
-        )
+                        return 0  # Did not receive a response in a single attempt.
+            raise TimeoutError(
+                "No response from DHCP server after {} retries.".format(attempt)
+            )
+        finally:
+            self._eth.socket_close(sock_num)  # Close the socket whatever happens.
 
     def _dhcp_state_machine(self, *, blocking: bool = False) -> None:
         """


### PR DESCRIPTION
Closes #121. Moved all references to hardware sockets in the DHCP module to `_handle_dhcp_message` and `_receive_dhcp_response`. Added `try… finally` block to ensure that the hardware socket is always closed.
Made the socket number a local method attribute since it doesn't need to be stored.
Removed unused methods to initialise and release hardware sockets.
Refactored DHCP module to use higher level calls to the `WIZNET5K` instance.
Renamed several methods in `WIZNET5K` as they are private and no longer called from outside `WIZNET5K`.
Added `_read_socket_reservations` and `_read_sndport` methods to `WIZNET5K` to help dumping of socket state for troubleshooting.
Tested with a DHCP server and without a DHCP server to force a TimeoutError. Hardware socket closed in both cases.
Tests carried out with `wiznet5k_simpletest.py` on w5100s, w5500 and w6100 chips.