### PR TITLE
Fix socket swap in socket.accept()

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -410,7 +410,7 @@ class socket:
         current_socknum = self._socknum
         # Create a new socket object and swap socket nums, so we can continue listening
         client_sock = socket()
-        self._socknum = client_sock._socknum
+        self._socknum = client_sock._socknum  # pylint: disable=protected-access
         client_sock._socknum = current_socknum  # pylint: disable=protected-access
         self._bind((None, self._listen_port))
         self.listen()

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -406,12 +406,12 @@ class socket:
                 self.close()
                 self.listen()
 
-        new_listen_socknum, addr = _the_interface.socket_accept(self._socknum)
+        _, addr = _the_interface.socket_accept(self._socknum)
         current_socknum = self._socknum
         # Create a new socket object and swap socket nums, so we can continue listening
         client_sock = socket()
+        self._socknum = client_sock._socknum
         client_sock._socknum = current_socknum  # pylint: disable=protected-access
-        self._socknum = new_listen_socknum
         self._bind((None, self._listen_port))
         self.listen()
         while self._status != wiznet5k.adafruit_wiznet5k.SNSR_SOCK_LISTEN:


### PR DESCRIPTION
Closes #129.  Prevents listening for connections on hardware socket 0 and marking unused sockets as reserved when `socket.accept()` is called and hardware socket 0 is available.

Tested with CircuitPython 8.2.0-rc.1 on a Raspberry Pi Pico with WIZnet Ethernet Hat (w5100s chipset) using my [CircuitPython WIZnet5k Socket Visualizer](https://github.com/fasteddy516/CircuitPython_Wiznet5k_Socket_Visualizer).

