### PR TITLE
Improve reset during initialization

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -219,10 +219,12 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
 
         # Reset wiznet module prior to initialization.
         if reset:
+            debug_msg("* Resetting WIZnet chip", self._debug)
+            reset.switch_to_output()
             reset.value = False
             time.sleep(0.1)
             reset.value = True
-            time.sleep(0.1)
+            time.sleep(5)
 
         # Setup chip_select pin.
         time.sleep(1)


### PR DESCRIPTION
Close #128.  Closes #124.  Improves the handling of the optional `reset` pin by calling `switch_to_output()` and increasing the delay at the end of the reset procedure.

Tested with CircuitPython 8.2.0-rc.1 on a Raspberry Pi Pico with WIZnet Ethernet Hat (w5100s chipset).