### PR TITLE
Correct error raised by bytes MAC address

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -386,7 +386,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-at
         """
         try:
             address = [int(x, 16) for x in address.split(":")]
-        except AttributeError:
+        except TypeError:
             pass
         try:
             if len(address) != 6:


### PR DESCRIPTION
Error should have been a `TypeError` not an `AttributeError` when passing in a bytes formatted MAC address.