### PR TITLE
Fix body recv when no content-length

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_wsgiserver.py
@@ -229,7 +229,7 @@ class WSGIServer:
             body = client.recv(int(env["CONTENT_LENGTH"]))
             env["wsgi.input"] = io.StringIO(body)
         else:
-            body = client.recv(1024)
+            body = client.recv(0)
             env["wsgi.input"] = io.StringIO(body)
         for name, value in headers.items():
             key = "HTTP_" + name.replace("-", "_").upper()


### PR DESCRIPTION
When there is no `content-length` key in the request headers, asking for bytes from the socket is going to always timeout because there is no data or shouldn't be any, since the no `content-length`.

Fixes #138