### PR TITLE
Handle SNSR_SOCK_CLOSE_WAIT during accept()

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -402,6 +402,9 @@ class socket:
         ):
             if self._timeout and 0 < self._timeout < time.monotonic() - stamp:
                 raise TimeoutError("Failed to accept connection.")
+            if self._status == wiznet5k.adafruit_wiznet5k.SNSR_SOCK_CLOSE_WAIT:
+                self._disconnect()
+                self.listen()
             if self._status == wiznet5k.adafruit_wiznet5k.SNSR_SOCK_CLOSED:
                 self.close()
                 self.listen()


### PR DESCRIPTION
If we receive SYN, ACK and the we get FIX from the other side really fast, the connection state can go straight to the closing phase. If that happends lets just finis the close and continue listening.