### PR TITLE
Properly close socked which is already in disconnection state

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -247,7 +247,7 @@ class socket:
         _the_interface.release_socket(self._socknum)
         if self._sock_type == SOCK_STREAM:
             _the_interface.write_snir(
-                self._socknum, 0xFF
+                self._socknum, 0xFF & (~wiznet5k.adafruit_wiznet5k.SNIR_DISCON)
             )  # Reset socket interrupt register.
             _the_interface.socket_disconnect(self._socknum)
             mask = (


### PR DESCRIPTION
The socker might be already disconnecting due to FIN from the other side, in this case still close the socket to finish the operation but do not reset the ISR, because we will not get another SNIR_DISCON and would end up in inifite loop.