### PR TITLE
replace time.monotonic with adafruit_ticks to preserve timing precision

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_dns.py
@@ -26,6 +26,7 @@ except ImportError:
 import time
 from random import getrandbits
 from micropython import const
+from adafruit_ticks import ticks_ms, ticks_diff
 
 _QUERY_FLAG = const(0x00)
 _OPCODE_STANDARD_QUERY = const(0x00)
@@ -261,9 +262,10 @@ class DNS:
         ipaddress = -1
         for _ in range(5):
             #  wait for a response
-            socket_timeout = time.monotonic() + 5.0
+            socket_timeout = 5000
+            start_time = ticks_ms()
             while not self._iface.socket_available(dns_socket, 0x02):
-                if time.monotonic() > socket_timeout:
+                if ticks_diff(ticks_ms(), start_time) > socket_timeout:
                     _debug_print(
                         debug=self._debug,
                         message="* DNS ERROR: Did not receive DNS response (socket timeout).",

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -31,6 +31,7 @@ from sys import byteorder
 from micropython import const
 
 import adafruit_wiznet5k as wiznet5k
+from adafruit_ticks import ticks_ms, ticks_diff
 
 # pylint: disable=invalid-name
 _the_interface: Optional[WIZNET5K] = None
@@ -396,12 +397,15 @@ class socket:
             the connection, and address is the address bound to the socket on the other
             end of the connection.
         """
-        stamp = time.monotonic()
+        stamp = ticks_ms()
         while self._status not in (
             wiznet5k.adafruit_wiznet5k.SNSR_SOCK_SYNRECV,
             wiznet5k.adafruit_wiznet5k.SNSR_SOCK_ESTABLISHED,
         ):
-            if self._timeout and 0 < self._timeout < time.monotonic() - stamp:
+            if (
+                self._timeout
+                and 0 < self._timeout < ticks_diff(ticks_ms(), stamp) / 1000
+            ):
                 raise TimeoutError("Failed to accept connection.")
             if self._status == wiznet5k.adafruit_wiznet5k.SNSR_SOCK_CLOSED:
                 self.close()
@@ -564,7 +568,7 @@ class socket:
         if not 0 <= nbytes <= len(buffer):
             raise ValueError("nbytes must be 0 to len(buffer)")
 
-        last_read_time = time.monotonic()
+        last_read_time = ticks_ms()
         num_to_read = len(buffer) if nbytes == 0 else nbytes
         num_read = 0
         while num_to_read > 0:
@@ -583,7 +587,7 @@ class socket:
 
             num_avail = self._available()
             if num_avail > 0:
-                last_read_time = time.monotonic()
+                last_read_time = ticks_ms()
                 bytes_to_read = min(num_to_read, num_avail)
                 if self._sock_type == SOCK_STREAM:
                     bytes_read = _the_interface.socket_read(
@@ -606,7 +610,7 @@ class socket:
             if self._timeout == 0:
                 # non-blocking mode
                 break
-            if time.monotonic() - last_read_time > self._timeout:
+            if ticks_diff(ticks_ms(), last_read_time) / 1000 > self._timeout:
                 raise timeout("timed out")
         return num_read
 
@@ -644,7 +648,7 @@ class socket:
 
         :return bytes: The data read from the socket.
         """
-        stamp = time.monotonic()
+        stamp = ticks_ms()
         while b"\r\n" not in self._buffer:
             avail = self._available()
             if avail:
@@ -655,7 +659,7 @@ class socket:
                 if (
                     self._timeout
                     and not avail
-                    and 0 < self._timeout < time.monotonic() - stamp
+                    and 0 < self._timeout < ticks_diff(ticks_ms(), stamp) / 1000
                 ):
                     self.close()
                     raise RuntimeError("Didn't receive response, failing out...")

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -25,13 +25,12 @@ except ImportError:
     pass
 
 import gc
-import time
 from sys import byteorder
 
 from micropython import const
+from adafruit_ticks import ticks_ms, ticks_diff
 
 import adafruit_wiznet5k as wiznet5k
-from adafruit_ticks import ticks_ms, ticks_diff
 
 # pylint: disable=invalid-name
 _the_interface: Optional[WIZNET5K] = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
+adafruit-circuitpython-ticks


### PR DESCRIPTION
Time monotonic continues to lose precision as uptime gets longer. This will cause spurious timeouts to occur after a few days depending on the duration of the socket timeout (e.g. 100msec), but will cause spurious timeouts even at 1sec if the uptime gets long enough. I've replaced all of the time.monotonics with adafruit_ticks.ticks_ms and the appropriate tick_diff math to compare with timeouts. This could also be fixed by using time.monotonic_ns as long as the nanosecond ints were subtracted from each other first before being divided into float seconds. Closes #152 