### PR TITLE
Core compatible constants & setsockopt

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k.py
@@ -183,10 +183,6 @@ def _unprettyfy(data: str, seperator: str, correct_length: int) -> bytes:
 class WIZNET5K:  # pylint: disable=too-many-public-methods, too-many-instance-attributes
     """Interface for WIZNET5K module."""
 
-    _TCP_MODE = const(0x21)
-    _UDP_MODE = const(0x02)
-    _TLS_MODE = const(0x03)  # This is NOT currently implemented
-
     _sockets_reserved = []
 
     # pylint: disable=too-many-arguments

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -145,9 +145,13 @@ def inet_ntoa(ip_address: Union[bytes, bytearray]) -> str:
     return _the_interface.pretty_ip(ip_address)
 
 
-SOCK_STREAM = const(0x21)  # TCP
-_TCP_MODE = 80
-SOCK_DGRAM = const(0x02)  # UDP
+# These must match circuitpython "socketpoool" values. However, we cannot
+# depend on socketpool being importable, so hard-code them here.
+SOCK_STREAM = 1
+SOCK_DGRAM = 2
+
+_SOCKET_TYPE_TO_WIZNET = b"\0\x21\2"
+
 AF_INET = const(3)
 _SOCKET_INVALID = const(255)
 
@@ -431,7 +435,7 @@ class socket:
             self._socknum,
             _the_interface.unpretty_ip(gethostbyname(address[0])),
             address[1],
-            self._sock_type,
+            _SOCKET_TYPE_TO_WIZNET[self._sock_type],
         )
         _the_interface.src_port = 0
         if not result:
@@ -674,7 +678,9 @@ class socket:
 
         :return int: Number of bytes available.
         """
-        return _the_interface.socket_available(self._socknum, self._sock_type)
+        return _the_interface.socket_available(
+            self._socknum, _SOCKET_TYPE_TO_WIZNET[self._sock_type]
+        )
 
     @_check_socket_closed
     def settimeout(self, value: Optional[float]) -> None:

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socket.py
@@ -152,6 +152,9 @@ SOCK_DGRAM = 2
 
 _SOCKET_TYPE_TO_WIZNET = b"\0\x21\2"
 
+SOL_SOCKET = 0xFFF
+SO_REUSEADDR = 0x0004
+
 AF_INET = const(3)
 _SOCKET_INVALID = const(255)
 
@@ -681,6 +684,20 @@ class socket:
         return _the_interface.socket_available(
             self._socknum, _SOCKET_TYPE_TO_WIZNET[self._sock_type]
         )
+
+    @_check_socket_closed
+    def setsockopt(  # pylint: disable=no-self-use
+        self, level: int, opt: int, value: any
+    ) -> None:
+        """
+        Set a socket option.
+
+        Only SOL_SOCKET SO_REUSEADDR is accepted (and the value is ignored).
+
+        Other calls result in OSError."""
+        if level == SOL_SOCKET and opt == SO_REUSEADDR:
+            return
+        raise OSError
 
     @_check_socket_closed
     def settimeout(self, value: Optional[float]) -> None:


### PR DESCRIPTION
This is needed as a part of enabling an implementation of SSL in the CircuitPython core to work with wiznet. See https://github.com/adafruit/circuitpython/pull/8954

Also closes #155 (not tested)