### PR TITLE
Remove timeout Exception

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_socketpool.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socketpool.py
@@ -21,9 +21,9 @@ try:
 except ImportError:
     pass
 
+import errno
 import gc
 from sys import byteorder
-from errno import ETIMEDOUT
 
 from micropython import const
 from adafruit_ticks import ticks_ms, ticks_diff
@@ -638,7 +638,7 @@ class Socket:
                 # non-blocking mode
                 break
             if ticks_diff(ticks_ms(), last_read_time) / 1000 > self._timeout:
-                raise timeout("timed out")
+                raise OSError(errno.ETIMEDOUT)
         return num_read
 
     @_check_socket_closed
@@ -813,11 +813,3 @@ class Socket:
     def proto(self):
         """Socket protocol (always 0x00 in this implementation)."""
         return 0
-
-
-class timeout(TimeoutError):  # pylint: disable=invalid-name
-    """TimeoutError class. An instance of this error will be raised by recv_into() if
-    the timeout has elapsed and we haven't received any data yet."""
-
-    def __init__(self, msg):
-        super().__init__(ETIMEDOUT, msg)


### PR DESCRIPTION
This removes the custom timeout Exception that makes this socket library behave like CPython versions pre 3.10 and updates it to behave like espressif and pico-w.

This matches the PR for ESP32SPI: https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/pull/206