### PR TITLE
Match core socket behaviour

### DIFF
--- a/adafruit_wiznet5k/adafruit_wiznet5k_socketpool.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socketpool.py
@@ -408,33 +408,50 @@ class Socket:
             end of the connection.
         """
         stamp = ticks_ms()
-        while self._status not in (
-            wiznet5k.adafruit_wiznet5k.SNSR_SOCK_SYNRECV,
-            wiznet5k.adafruit_wiznet5k.SNSR_SOCK_ESTABLISHED,
-            wiznet5k.adafruit_wiznet5k.SNSR_SOCK_LISTEN,
-        ):
-            if (
-                self._timeout
-                and 0 < self._timeout < ticks_diff(ticks_ms(), stamp) / 1000
+        while True:
+            while self._status not in (
+                wiznet5k.adafruit_wiznet5k.SNSR_SOCK_SYNRECV,
+                wiznet5k.adafruit_wiznet5k.SNSR_SOCK_ESTABLISHED,
+                wiznet5k.adafruit_wiznet5k.SNSR_SOCK_LISTEN,
             ):
-                raise TimeoutError("Failed to accept connection.")
-            if self._status == wiznet5k.adafruit_wiznet5k.SNSR_SOCK_CLOSE_WAIT:
-                self._disconnect()
-                self.listen()
-            if self._status == wiznet5k.adafruit_wiznet5k.SNSR_SOCK_CLOSED:
-                self.close()
-                self.listen()
-
-        _, addr = self._interface.socket_accept(self._socknum)
-        current_socknum = self._socknum
-        # Create a new socket object and swap socket nums, so we can continue listening
-        client_sock = Socket(self._socket_pool)
-        self._socknum = client_sock._socknum  # pylint: disable=protected-access
-        client_sock._socknum = current_socknum  # pylint: disable=protected-access
-        self._bind((None, self._listen_port))
-        self.listen()
-        if self._status != wiznet5k.adafruit_wiznet5k.SNSR_SOCK_LISTEN:
-            raise RuntimeError("Failed to open new listening socket")
+                if (
+                    self._timeout
+                    and 0 < self._timeout < ticks_diff(ticks_ms(), stamp) / 1000
+                ):
+                    raise TimeoutError("Failed to accept connection.")
+                if self._status == wiznet5k.adafruit_wiznet5k.SNSR_SOCK_CLOSE_WAIT:
+                    self._disconnect()
+                    self.listen()
+                if self._status == wiznet5k.adafruit_wiznet5k.SNSR_SOCK_CLOSED:
+                    self.close()
+                    self.listen()
+    
+            _, addr = self._interface.socket_accept(self._socknum)
+            # if any of the following conditions are true, we haven't accepted a connection
+            if (
+                addr[0] == "0.0.0.0"
+                or addr[1] == 0
+                or self._interface.socket_status(self._socknum) != wiznet5k.adafruit_wiznet5k.SNSR_SOCK_ESTABLISHED
+            ):
+                if self._timeout == 0:
+                    # non-blocking mode
+                    raise OSError(errno.EAGAIN)
+                elif self._timeout and 0 < self._timeout < ticks_diff(ticks_ms(), stamp) / 1000:
+                    # blocking mode with timeout
+                    raise OSError(errno.ETIMEDOUT)
+                else:
+                    # blocking mode / timeout not expired
+                    continue
+            current_socknum = self._socknum
+            # Create a new socket object and swap socket nums, so we can continue listening
+            client_sock = Socket(self._socket_pool)
+            self._socknum = client_sock._socknum  # pylint: disable=protected-access
+            client_sock._socknum = current_socknum  # pylint: disable=protected-access
+            self._bind((None, self._listen_port))
+            self.listen()
+            if self._status != wiznet5k.adafruit_wiznet5k.SNSR_SOCK_LISTEN:
+                raise RuntimeError("Failed to open new listening socket")
+            break
         return client_sock, addr
 
     @_check_socket_closed

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socketpool.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socketpool.py
@@ -632,7 +632,10 @@ class Socket:
                 continue
             if self._timeout == 0:
                 # non-blocking mode
-                break
+                if num_read == 0:
+                    raise OSError(errno.EAGAIN)
+                else:
+                    break
             if ticks_diff(ticks_ms(), last_read_time) / 1000 > self._timeout:
                 raise OSError(errno.ETIMEDOUT)
         return num_read

--- a/adafruit_wiznet5k/adafruit_wiznet5k_socketpool.py
+++ b/adafruit_wiznet5k/adafruit_wiznet5k_socketpool.py
@@ -705,6 +705,8 @@ class Socket:
         Mark the socket closed. Once that happens, all future operations on the socket object
         will fail. The remote end will receive no more data.
         """
+        if self._sock_type == SocketPool.SOCK_STREAM:
+            self._disconnect()
         self._interface.release_socket(self._socknum)
         self._interface.socket_close(self._socknum)
         self._socket_closed = True


### PR DESCRIPTION
While porting code from a WiFi-based board (Pico 2 W) to a wired ethernet board (WIZnet W5500-EVB-Pico2) I ran into problems caused by differences in behaviour between CircuitPython core sockets and those provided by this driver.  This pull request aims to correct three discrepancies with modifications to `adafruit_wiznet5k_socketpool.py`:

1) `recv_into()` now raises `OSError(errno.EAGAIN)` when the socket is in non-blocking mode and nothing is received.

2) Instead of always returning instantly with `addr = ("0.0.0.0", 0)`, `accept()` now respects the specified socket mode, i.e.:
    - In blocking mode, it blocks until a connection is accepted.
    - If a timeout has been specified, `OSError(errno.ETIMEDOUT)` is raised when the timeout expires.
    - In non-blocking mode `OSError(errno.EAGAIN)` is raised if there is no connection to accept.  
   
    This has the added benefit of avoiding the overhead of the WIZnet socket swap dance until an actual connection is established.

3) `close()` now calls `_disconnect` on `SOCK_STREAM` sockets.  I'm not 100% sure on this one, but I noticed while comparing functionally equivalent code between Pico WiFi and WIZnet wired using PuTTy, calling `close()` on the Pico correctly closed my PuTTy session, but calling `close()` on the WIZnet just left my PuTTy session hanging.  Adding the `_disconnect()` call in `close()` made the behaviour between the two match.

For testing 1 and 2 I used the script [available here](https://gist.github.com/fasteddy516/c04b841f0d29aaf6768656bc65fa37f4).  While testing `accept()` I used a modified version of @niclas-gr's script from #170 [available here](https://gist.github.com/fasteddy516/45875621a075195dbd51d2bc99ff6529).

This pull request resolves the issues (that I am aware of) that I reported in #177, and I believe it resolves #170 as well.  The `wiznet5k_simpletest.py`, `wiznet5k_httpserver.py` and `wiznet5k_aio_post.py` examples all ran correctly with these changes in place.  (Side note: the `api.coindesk.com` URL in `simpletest` appears to no longer be valid.)